### PR TITLE
feat(relatórios): adicionar relatório quantitativo de participação e avaliação

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,151 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Engaja** is a Laravel 12 application for managing educational events, enrollments, attendance, and engagement reports for the Alfa-EJA project. It tracks formations, workshops, meetings, and live sessions for educational institutions.
+
+## Tech Stack
+
+- **Backend:** Laravel 12 (PHP 8.2+)
+- **Frontend:** Bootstrap 5 + Blade + Livewire 4
+- **Database:** PostgreSQL
+- **Auth:** Laravel Breeze + Spatie Laravel Permission
+- **PDF:** barryvdh/laravel-dompdf + setasign/fpdi
+- **Imports:** maatwebsite/excel (xlsx)
+- **QR Code:** simplesoftwareio/simple-qrcode
+
+## Common Commands
+
+```bash
+# Development
+php artisan serve        # Start dev server (http://localhost:8000)
+npm run dev              # Compile assets (Vite, watch mode)
+npm run build            # Compile for production
+
+# Database
+php artisan migrate
+php artisan migrate --seed   # Fresh setup with roles, permissions, seed data
+php artisan migrate:fresh --seed
+
+# Code quality
+./vendor/bin/pint        # Laravel Pint (PSR-12 code style fixer)
+
+# Tests
+php artisan test
+php artisan test --filter TestClassName   # Run single test
+
+# Scheduling & Cache
+php artisan schedule:list                 # List all scheduled tasks
+php artisan schedule:run                  # Simulate scheduler (runs due tasks)
+php artisan limesurvey:importar-dados     # Import LimeSurvey data to cache (24h TTL)
+```
+
+## Architecture
+
+### Domain Model
+
+The core hierarchy is: **Evento → Atividade → Presença/Inscrição**
+
+- `Evento` — an educational event, tied to an `Eixo` (thematic axis), `acao_geral`, and `subacao` (from Alfa-EJA project constants defined in the model). Has checklists for planning/closure.
+- `Atividade` — a session/moment within an event, tied to a `Municipio`. Stores `carga_horaria` in **minutes** (column name is legacy). Has planning and closure checklists (JSON columns).
+- `Participante` — person participating; separate from `User`.
+- `Inscricao` — enrollment of a Participante in an Evento.
+- `Presenca` — attendance record of a Participante at an Atividade. Has `avaliacao_respondida` (bool) flag.
+- `Agendamento` — scheduling of a Participante for an AtividadeAcao.
+
+### Naming Conventions
+
+| Term in UI | Model | Table |
+|---|---|---|
+| Ação pedagógica | `Evento` | `eventos` |
+| Momento / Encontro | `Atividade` | `atividades` |
+| Relatório do Momento | `AvaliacaoAtividade` | `avaliacao_atividades` |
+
+### Authorization
+
+Uses **Spatie Laravel Permission** with roles and permissions.
+
+Roles: `administrador`, `gerente`, `eq_pedagogica`, `articulador`, `participante`, `SME`
+
+Permissions follow the pattern `resource.action` (e.g., `evento.criar`, `presenca.abrir`). Route middleware uses `role:` and `permission:` guards. Most management routes require role `administrador|gerente|eq_pedagogica|articulador`.
+
+### Key Patterns
+
+- **Repositories:** `app/Repositories/` — currently only `BiValorRepository` for BI queries.
+- **Services:** `app/Services/` — `LimeSurveyDashboardService`, `ParticipantesExclusivosService`, and BI services.
+- **Console Commands:** `app/Console/Commands/` — `ImportLimeSurveyData` (daily cache warm-up), `ImportBiGeral` (CSV import).
+- **Livewire:** `app/Livewire/Dashboards/` and `app/Livewire/Graficos/` — interactive dashboard components.
+- **Imports:** `app/Imports/` — Excel importers via maatwebsite/excel with tolerant header parsing.
+- **Exports:** `app/Exports/` — Excel exports.
+- **PDF:** `app/Pdf/` — PDF generation classes; views in `resources/views/layouts/pdf-alfa-eja.blade.php`.
+- **ViewModels:** `app/ViewModels/` — view data transformation.
+- **Policies:** `app/Policies/` — model-level authorization.
+
+### Filter + Sort Pattern (Blade reports)
+
+Used in `DashboardController::index()` and `RelatorioQuantitativoController::index()`:
+- `$sortable = ['key' => 'db_column']` map; direction validated to `asc`/`desc`.
+- Filters applied with `->when($value, fn($q) => ...)`.
+- `->withCount(['relation as alias' => fn($q) => $q->where(...)])` for aggregated counts.
+- `->appends($request->query())` preserves filter state across pagination.
+- Sort links built inline in Blade with `http_build_query` — no shared helper function.
+
+### Import Flow (Presença/Inscrição)
+
+Imports follow a multi-step preview/confirm pattern:
+1. Upload → parse xlsx → store in session
+2. Preview page (paginated)
+3. Confirm → persist to database
+
+### Seeding
+
+`RolesPermissionsSeeder` sets up all roles and permissions. `DatabaseSeeder` creates a default admin user (`admin@engaja.local`) with sample events/activities. Always run `--seed` on fresh installs.
+
+### Reports (Relatórios)
+
+**Relatórios do Momento** (`/relatorios-avaliacao`):
+- `AvaliacaoAtividadeController` — qualitative reports per atividade, grouped by ação/momento.
+- Views: `resources/views/avaliacao-atividade/`.
+
+**Relatório Quantitativo** (`/relatorio-quantitativo`):
+- `RelatorioQuantitativoController` — attendance and evaluation counts per encontro.
+- Filters: ação, momento, município, date range, período (manhã/tarde/noite via `hora_inicio`).
+- Table grouped by ação with subtotal rows; all columns sortable.
+- Cascading filters: selecting ação triggers a `fetch` to `GET /relatorio-quantitativo/momentos` (JSON) which returns filtered `momentos` and `municipios`.
+- Views: `resources/views/relatorio-quantitativo/`.
+
+### LimeSurvey Integration & Avaliacoes Dashboard
+
+**Routes & Views:**
+- `GET /dashboards/leitura-mundo` (`dashboards.leitura-mundo`) — survey list via `DashboardController::leituraMundo()`.
+- `GET /dashboards/avaliacoes?fonte=limesurvey&survey_id=X` (`dashboards.avaliacoes`) — dashboard entry point.
+- `GET /dashboards/avaliacoes/dados?...` (`dashboards.avaliacoes.data`) — AJAX endpoint returning `{totais, perguntas, bi_matrizes, question_blocks, recentes}`.
+- View partials in `resources/views/dashboards/avaliacoes/`: `_filtros`, `_cards-totais`, `_bi-matriz`, `_modal-respostas`.
+
+**Data Flow:**
+1. Frontend JS (`resources/js/dashboards/avaliacoes.js`) fetches `/dashboards/avaliacoes/dados` with filters.
+2. `DashboardController::avaliacoesDataLimeSurvey()` → `LimeSurveyDashboardService::buildPayload($request)`.
+3. Service returns structured payload with questions, responses, matrix analyses, organized blocks.
+
+**Caching & Scheduling:**
+- Service uses `Cache::remember()` with **database driver** (configurable TTL via `LIMESURVEY_CACHE_MINUTES`, default 5 min).
+- **Cache keys:** `limesurvey:{surveyId}:questions`, `limesurvey:{surveyId}:responses`, `limesurvey:{surveyId}:answer_options:{qid}` (type-L questions only).
+- **Daily warm-up:** `php artisan limesurvey:importar-dados` runs at 00:00 UTC (see `routes/console.php` for schedule), caching all active surveys for 24 hours. Fallback to on-demand fetch if scheduler fails.
+- Manual trigger: `php artisan limesurvey:importar-dados` or `php artisan limesurvey:importar-dados --survey_id=X`.
+
+**LimeSurvey Client** (`app/Services/LimeSurvey/LimeSurveyClient.php`):
+- JSON-RPC 2.0 client; session-based (auto-acquired/released per call).
+- Methods: `listQuestions(surveyId)`, `exportResponses(surveyId)` (CSV base64), `listParticipants()`, `getQuestionProperties(qid)`, `listSurveys()`.
+- Config via `config/services.php` (env: `LIMESURVEY_URL`, `USERNAME`, `PASSWORD`, `SURVEY_ID`, `CACHE_MINUTES`, `VERIFY_SSL`, `TIMEOUT`).
+
+**Service** (`app/Services/LimeSurvey/LimeSurveyDashboardService.php`):
+- Normalizes questions, builds simple questions and matrix blocks.
+- Supports município-level aggregation (email-to-município mapping).
+- Infers question types: `texto`, `boolean`, `escala`, `numero`.
+- Date filters from `de` / `ate` request params applied post-cache.
+
+**Frontend Rendering** (Chart.js, not ApexCharts):
+- Two paths: **new** (`question_blocks`) uses `renderSimpleQuestionCard`/`renderMatrixBlockCard`; **legacy** (`perguntas`/`bi_matrizes`) uses `renderLegacyCharts`.
+- Circular charts (doughnut, polarArea): use `maintainAspectRatio: false` + `canvas.style.height` to prevent excessive height.

--- a/app/Http/Controllers/RelatorioQuantitativoController.php
+++ b/app/Http/Controllers/RelatorioQuantitativoController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Atividade;
+use App\Models\Evento;
+use App\Models\Municipio;
+use Illuminate\Http\Request;
+
+class RelatorioQuantitativoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $eventoId    = $request->integer('evento_id');
+        $descricao   = trim((string) $request->get('descricao', ''));
+        $municipioId = $request->integer('municipio_id');
+        $de          = $request->date('de');
+        $ate         = $request->date('ate');
+        $periodo     = $request->get('periodo', '');
+
+        $sort = $request->get('sort', 'dia');
+        $dir  = $request->get('dir', 'asc') === 'asc' ? 'asc' : 'desc';
+
+        $sortable = [
+            'acao'      => 'eventos.nome',
+            'momento'   => 'atividades.descricao',
+            'municipio' => 'municipios.nome',
+            'dia'       => 'atividades.dia',
+            'periodo'   => 'atividades.hora_inicio',
+            'previstas' => 'atividades.publico_esperado',
+            'presentes' => 'presentes_count',
+            'avaliacoes' => 'avaliacoes_count',
+        ];
+        $orderByCol = $sortable[$sort] ?? 'atividades.dia';
+
+        $query = Atividade::query()
+            ->select([
+                'atividades.id',
+                'atividades.evento_id',
+                'atividades.municipio_id',
+                'atividades.descricao',
+                'atividades.dia',
+                'atividades.hora_inicio',
+                'atividades.hora_fim',
+                'atividades.publico_esperado',
+                'eventos.nome as evento_nome',
+                'municipios.nome as municipio_nome',
+            ])
+            ->leftJoin('eventos', 'eventos.id', '=', 'atividades.evento_id')
+            ->leftJoin('municipios', 'municipios.id', '=', 'atividades.municipio_id')
+            ->withCount([
+                'presencas as presentes_count' => fn ($q) => $q->where('status', 'presente'),
+                'presencas as avaliacoes_count' => fn ($q) => $q->where('status', 'presente')
+                    ->where('avaliacao_respondida', true),
+            ])
+            ->whereNull('atividades.deleted_at')
+            ->whereNotNull('atividades.evento_id');
+
+        $query->when($eventoId,    fn ($q) => $q->where('atividades.evento_id',    $eventoId));
+        $query->when($municipioId, fn ($q) => $q->where('atividades.municipio_id', $municipioId));
+        $query->when($descricao,   fn ($q) => $q->where('atividades.descricao',    $descricao));
+
+        $query->when($de && $ate,  fn ($q) => $q->whereBetween('atividades.dia', [$de, $ate]));
+        $query->when($de && ! $ate, fn ($q) => $q->where('atividades.dia', '>=', $de));
+        $query->when(! $de && $ate, fn ($q) => $q->where('atividades.dia', '<=', $ate));
+
+        $query->when($periodo === 'manha', fn ($q) =>
+            $q->whereRaw("TIME(atividades.hora_inicio) < '12:00:00'"));
+        $query->when($periodo === 'tarde', fn ($q) =>
+            $q->whereRaw("TIME(atividades.hora_inicio) >= '12:00:00'")
+              ->whereRaw("TIME(atividades.hora_inicio) < '18:00:00'"));
+        $query->when($periodo === 'noite', fn ($q) =>
+            $q->whereRaw("TIME(atividades.hora_inicio) >= '18:00:00'"));
+
+        $query->orderBy($orderByCol, $dir)
+              ->orderBy('eventos.nome', 'asc')
+              ->orderBy('atividades.dia', 'asc')
+              ->orderBy('atividades.id', 'asc');
+
+        $atividades = $query->get();
+
+        $eventos = Evento::query()->orderBy('nome')->pluck('nome', 'id');
+
+        $municipios = Municipio::query()
+            ->with('estado:id,sigla')
+            ->whereIn('id',
+                Atividade::query()
+                    ->whereNotNull('municipio_id')
+                    ->distinct()
+                    ->pluck('municipio_id')
+            )
+            ->orderBy('nome')
+            ->get();
+
+        $momentos = Atividade::query()
+            ->select('descricao')
+            ->whereNotNull('descricao')
+            ->where('descricao', '!=', '')
+            ->distinct()
+            ->orderBy('descricao')
+            ->pluck('descricao');
+
+        return view('relatorio-quantitativo.index',
+            compact('atividades', 'eventos', 'municipios', 'momentos', 'sort', 'dir'));
+    }
+
+    public function momentos(Request $request)
+    {
+        $eventoId = $request->integer('evento_id');
+
+        $momentos = Atividade::query()
+            ->select('descricao')
+            ->when($eventoId, fn ($q) => $q->where('evento_id', $eventoId))
+            ->whereNotNull('descricao')
+            ->where('descricao', '!=', '')
+            ->distinct()
+            ->orderBy('descricao')
+            ->pluck('descricao');
+
+        $municipios = Municipio::query()
+            ->with('estado:id,sigla')
+            ->whereIn('id',
+                Atividade::query()
+                    ->select('municipio_id')
+                    ->when($eventoId, fn ($q) => $q->where('evento_id', $eventoId))
+                    ->whereNotNull('municipio_id')
+                    ->distinct()
+                    ->pluck('municipio_id')
+            )
+            ->orderBy('nome')
+            ->get(['id', 'nome', 'estado_id'])
+            ->map(fn ($m) => ['id' => $m->id, 'nome' => $m->nome_com_estado]);
+
+        return response()->json(['momentos' => $momentos, 'municipios' => $municipios]);
+    }
+}

--- a/resources/views/layouts/partials/admin-sidebar.blade.php
+++ b/resources/views/layouts/partials/admin-sidebar.blade.php
@@ -153,6 +153,14 @@
         </span>
         <span class="admin-nav-text">Relatórios do Momento</span>
       </a>
+      <a class="admin-nav-link {{ request()->routeIs('relatorio-quantitativo.*') ? 'active' : '' }}" href="{{ route('relatorio-quantitativo.index') }}">
+        <span class="admin-nav-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M0 0h1v15h15v1H0zm10 3.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-1 0V4.9l-3.613 4.417a.5.5 0 0 1-.74.037L7.06 6.767l-3.656 5.027a.5.5 0 0 1-.808-.588l4-5.5a.5.5 0 0 1 .758-.06l2.609 2.61L13.445 4H10.5a.5.5 0 0 1-.5-.5"/>
+          </svg>
+        </span>
+        <span class="admin-nav-text">Relatório Quantitativo</span>
+      </a>
     </div>
   @endhasanyrole
 

--- a/resources/views/relatorio-quantitativo/index.blade.php
+++ b/resources/views/relatorio-quantitativo/index.blade.php
@@ -1,0 +1,231 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+
+    <div class="d-flex flex-wrap justify-content-between align-items-start mb-3 gap-2">
+        <div>
+            <p class="text-uppercase small text-muted mb-1">Relatórios</p>
+            <h1 class="h4 mb-0">Quantidade de participação e avaliação por encontro</h1>
+        </div>
+    </div>
+
+    {{-- Filtros --}}
+    <div class="card shadow-sm mb-4">
+        <div class="card-body py-3">
+            <form method="GET" action="{{ route('relatorio-quantitativo.index') }}" class="row g-2 align-items-end">
+
+                <div class="col-md-3 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Ação</label>
+                    <select name="evento_id" id="filter-evento" class="form-select form-select-sm">
+                        <option value="">Todas</option>
+                        @foreach($eventos as $id => $nome)
+                            <option value="{{ $id }}" @selected(request('evento_id') == $id)>{{ $nome }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="col-md-3 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Momento</label>
+                    <select name="descricao" id="filter-momento" class="form-select form-select-sm">
+                        <option value="">Todos</option>
+                        @foreach($momentos as $m)
+                            <option value="{{ $m }}" @selected(request('descricao') == $m)>{{ $m }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="col-md-3 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Município</label>
+                    <select name="municipio_id" id="filter-municipio" class="form-select form-select-sm">
+                        <option value="">Todos</option>
+                        @foreach($municipios as $municipio)
+                            <option value="{{ $municipio->id }}" @selected(request('municipio_id') == $municipio->id)>
+                                {{ $municipio->nome_com_estado }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="col-6 col-md-2 col-lg-1">
+                    <label class="form-label mb-1 small fw-semibold">De</label>
+                    <input type="date" name="de" value="{{ request('de') }}" class="form-control form-control-sm">
+                </div>
+
+                <div class="col-6 col-md-2 col-lg-1">
+                    <label class="form-label mb-1 small fw-semibold">Até</label>
+                    <input type="date" name="ate" value="{{ request('ate') }}" class="form-control form-control-sm">
+                </div>
+
+                <div class="col-md-2 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Período</label>
+                    <select name="periodo" class="form-select form-select-sm">
+                        <option value="">Todos</option>
+                        <option value="manha" @selected(request('periodo') == 'manha')>Manhã</option>
+                        <option value="tarde" @selected(request('periodo') == 'tarde')>Tarde</option>
+                        <option value="noite" @selected(request('periodo') == 'noite')>Noite</option>
+                    </select>
+                </div>
+
+                <input type="hidden" name="sort" value="{{ request('sort', 'dia') }}">
+                <input type="hidden" name="dir"  value="{{ request('dir', 'asc') }}">
+
+                <div class="col-auto d-flex gap-2">
+                    <button type="submit" class="btn btn-sm text-white" style="background-color:#421944;">Filtrar</button>
+                    <a href="{{ route('relatorio-quantitativo.index') }}" class="btn btn-outline-secondary btn-sm">Limpar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {{-- Tabela --}}
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            @php
+                function rq_sort_link(string $label, string $key): string {
+                    $curr   = request('sort', 'dia');
+                    $curDir = request('dir', 'asc') === 'asc' ? 'asc' : 'desc';
+                    $next   = ($curr === $key && $curDir === 'asc') ? 'desc' : 'asc';
+                    $params = array_merge(request()->except('page'), ['sort' => $key, 'dir' => $next]);
+                    $url    = request()->url() . '?' . http_build_query($params);
+                    $arrow  = ($curr === $key) ? ($curDir === 'asc' ? ' ↑' : ' ↓') : '';
+                    return '<a href="' . e($url) . '" class="text-decoration-none text-dark">'
+                         . e($label)
+                         . '<span class="text-muted small">' . $arrow . '</span></a>';
+                }
+            @endphp
+
+            @if($atividades->isEmpty())
+                <div class="p-4 text-center text-muted">Nenhum encontro encontrado com os filtros aplicados.</div>
+            @else
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>{!! rq_sort_link('Ação', 'acao') !!}</th>
+                            <th>{!! rq_sort_link('Momento', 'momento') !!}</th>
+                            <th>{!! rq_sort_link('Município', 'municipio') !!}</th>
+                            <th>{!! rq_sort_link('Data', 'dia') !!}</th>
+                            <th>{!! rq_sort_link('Período', 'periodo') !!}</th>
+                            <th class="text-end">{!! rq_sort_link('Qtd Previstas', 'previstas') !!}</th>
+                            <th class="text-end">{!! rq_sort_link('Qtd Presentes', 'presentes') !!}</th>
+                            <th class="text-end">Presentes / Previstas</th>
+                            <th class="text-end">{!! rq_sort_link('Qtd Avaliações', 'avaliacoes') !!}</th>
+                            <th class="text-end">Avaliações / Presentes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($atividades->groupBy('evento_nome') as $nomeAcao => $grupo)
+
+                            @foreach($grupo as $a)
+                            @php
+                                $horaStr = substr($a->hora_inicio ?? '', 0, 5);
+                                $hora    = (int) substr($horaStr, 0, 2);
+                                $periodoLabel = $hora < 12 ? 'Manhã' : ($hora < 18 ? 'Tarde' : 'Noite');
+
+                                $previstas  = (int) $a->publico_esperado;
+                                $presentes  = (int) $a->presentes_count;
+                                $avaliacoes = (int) $a->avaliacoes_count;
+
+                                $propPres = $previstas > 0 ? round($presentes  / $previstas  * 100, 1) : 0;
+                                $propAval = $presentes > 0 ? round($avaliacoes / $presentes  * 100, 1) : 0;
+                            @endphp
+                            <tr>
+                                <td>{{ $a->evento_nome ?? '—' }}</td>
+                                <td>{{ $a->descricao ?? '—' }}</td>
+                                <td>{{ $a->municipio_nome ?? '—' }}</td>
+                                <td>{{ $a->dia ? \Carbon\Carbon::parse($a->dia)->format('d/m/Y') : '—' }}</td>
+                                <td>{{ $horaStr ? $periodoLabel . ' (' . $horaStr . ')' : '—' }}</td>
+                                <td class="text-end">{{ $previstas ?: '—' }}</td>
+                                <td class="text-end">{{ $presentes }}</td>
+                                <td class="text-end">{{ $previstas > 0 ? $propPres . '%' : '—' }}</td>
+                                <td class="text-end">{{ $avaliacoes }}</td>
+                                <td class="text-end">{{ $presentes > 0 ? $propAval . '%' : '—' }}</td>
+                            </tr>
+                            @endforeach
+
+                            @php
+                                $totalPrevistas  = $grupo->sum('publico_esperado');
+                                $totalPresentes  = $grupo->sum('presentes_count');
+                                $totalAvaliacoes = $grupo->sum('avaliacoes_count');
+                                $propTotPres = $totalPrevistas > 0
+                                    ? round($totalPresentes  / $totalPrevistas  * 100, 1) : 0;
+                                $propTotAval = $totalPresentes > 0
+                                    ? round($totalAvaliacoes / $totalPresentes  * 100, 1) : 0;
+                            @endphp
+                            <tr style="background-color:#e8daea; font-weight:700;">
+                                <td colspan="5" class="text-end pe-3">
+                                    Subtotal — {{ $nomeAcao ?? 'Sem ação' }}
+                                </td>
+                                <td class="text-end">{{ $totalPrevistas ?: '—' }}</td>
+                                <td class="text-end">{{ $totalPresentes }}</td>
+                                <td class="text-end">{{ $totalPrevistas > 0 ? $propTotPres . '%' : '—' }}</td>
+                                <td class="text-end">{{ $totalAvaliacoes }}</td>
+                                <td class="text-end">{{ $totalPresentes > 0 ? $propTotAval . '%' : '—' }}</td>
+                            </tr>
+
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endif
+        </div>
+    </div>
+
+</div>
+
+<script>
+(function () {
+    var eventoSelect    = document.getElementById('filter-evento');
+    var momentoSelect   = document.getElementById('filter-momento');
+    var municipioSelect = document.getElementById('filter-municipio');
+
+    if (!eventoSelect) return;
+
+    var endpointBase      = '{{ route('relatorio-quantitativo.momentos') }}';
+    var selectedMomento   = '{{ addslashes(request('descricao', '')) }}';
+    var selectedMunicipio = '{{ request('municipio_id', '') }}';
+
+    function rebuildStringSelect(selectEl, items, currentVal) {
+        var first = selectEl.options[0];
+        selectEl.innerHTML = '';
+        selectEl.appendChild(first);
+        items.forEach(function (item) {
+            var opt = document.createElement('option');
+            opt.value = item;
+            opt.text  = item;
+            if (item === currentVal) opt.selected = true;
+            selectEl.appendChild(opt);
+        });
+    }
+
+    function rebuildObjectSelect(selectEl, items, currentVal) {
+        var first = selectEl.options[0];
+        selectEl.innerHTML = '';
+        selectEl.appendChild(first);
+        items.forEach(function (item) {
+            var opt = document.createElement('option');
+            opt.value = item.id;
+            opt.text  = item.nome;
+            if (String(item.id) === String(currentVal)) opt.selected = true;
+            selectEl.appendChild(opt);
+        });
+    }
+
+    eventoSelect.addEventListener('change', function () {
+        var eventoId = this.value;
+        var url      = endpointBase + (eventoId ? '?evento_id=' + encodeURIComponent(eventoId) : '');
+
+        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                rebuildStringSelect(momentoSelect,   data.momentos,   selectedMomento);
+                rebuildObjectSelect(municipioSelect, data.municipios, selectedMunicipio);
+            })
+            .catch(function (err) {
+                console.error('Erro ao carregar filtros:', err);
+            });
+    });
+})();
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\QuestaoController;
 use App\Http\Controllers\RegiaoController;
 use App\Http\Controllers\TemplateAvaliacaoController;
+use App\Http\Controllers\RelatorioQuantitativoController;
 use App\Http\Controllers\UserManagementController;
 use Illuminate\Support\Facades\Route;
 
@@ -260,6 +261,13 @@ Route::middleware(['auth', 'role:administrador|gerente|eq_pedagogica|articulador
 
     Route::get('/atividades/{atividade}/relatorios-avaliacao/pdf-consolidado', [AvaliacaoAtividadeController::class, 'baixarTodosPorAtividade'])
         ->name('avaliacao-atividade.download-all');
+});
+
+Route::middleware(['auth', 'role:administrador|gerente|eq_pedagogica|articulador'])->group(function () {
+    Route::get('/relatorio-quantitativo', [RelatorioQuantitativoController::class, 'index'])
+        ->name('relatorio-quantitativo.index');
+    Route::get('/relatorio-quantitativo/momentos', [RelatorioQuantitativoController::class, 'momentos'])
+        ->name('relatorio-quantitativo.momentos');
 });
 
 Route::middleware(['auth', 'role:administrador|gerente|eq_pedagogica|articulador'])->group(function () {


### PR DESCRIPTION
- Nova página GET /relatorio-quantitativo com filtros cascata (ação → momento/município)
- Tabela com contagem de presentes e avaliações respondidas por encontro
- Colunas ordenáveis: ação, momento, município, data, período, qtd previstas, qtd presentes, proporção presentes/previstas, qtd avaliações, proporção avaliações/presentes
- Período calculado por hora_inicio (manhã < 12h, tarde 12-18h, noite >= 18h)
- Agrupamento por ação com linhas de subtotal (totalizadores) em roxo (#e8daea)
- Endpoint AJAX GET /relatorio-quantitativo/momentos retorna momentos e municípios filtrados
- Filtros atualizam automaticamente via fetch() vanilla JS (sem Livewire)
- Link "Relatório Quantitativo" adicionado na sidebar seção Relatórios
- CLAUDE.md atualizado com documentação da nova feature e padrões de relatórios