### PR TITLE
feat(painel-gerencial): painel gerencial de quantitativos

### DIFF
--- a/app/Exports/PainelGerencialExport.php
+++ b/app/Exports/PainelGerencialExport.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Exports;
+
+use App\Services\PainelGerencialService;
+use Illuminate\Http\Request;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+
+/**
+ * Exporta o painel gerencial em XLSX com uma aba por bloco de métrica.
+ */
+class PainelGerencialExport implements WithMultipleSheets
+{
+    public function __construct(private Request $request) {}
+
+    /**
+     * @return array<int, FromArray>
+     */
+    public function sheets(): array
+    {
+        $payload = app(PainelGerencialService::class)->buildPayload($this->request);
+        $k = $payload['kpis'];
+
+        return [
+            new PainelGerencialSheet('Resumo', ['Indicador', 'Valor'], [
+                ['Municípios ativos', $k['municipios_ativos']],
+                ['Participantes totais', $k['participantes_totais']],
+                ['Participantes únicos', $k['participantes_unicos']],
+                ['Eventos realizados', $k['eventos_realizados']],
+                ['Horas presenciais', $k['horas_presenciais']],
+                ['Horas EaD', $k['horas_ead']],
+                ['Horas híbridas', $k['horas_hibrido']],
+                ['Certificados emitidos', $k['certificados_emitidos']],
+                ['Avaliações respondidas', $k['avaliacoes_respondidas']],
+                ['Pendências de documentação', $k['pendencias_documentacao']],
+            ]),
+
+            new PainelGerencialSheet(
+                'Metas por Ação',
+                ['Ação', 'Previstas', 'Inscritos', 'Presentes', 'Avaliações', '% Realizado'],
+                array_map(fn ($r) => [
+                    $r['acao'], $r['previstas'], $r['inscritos'], $r['presentes'], $r['avaliacoes'], $r['pct_realizado'],
+                ], $payload['metas_por_acao'])
+            ),
+
+            new PainelGerencialSheet(
+                'Por Região',
+                ['Região', 'Previstas', 'Presentes', '% Realizado'],
+                array_map(fn ($r) => [$r['regiao'], $r['previstas'], $r['presentes'], $r['pct_realizado']], $payload['participacao_por_regiao'])
+            ),
+
+            new PainelGerencialSheet(
+                'Segmentos',
+                ['Segmento', 'Presentes', 'Participantes únicos'],
+                array_map(fn ($r) => [$r['segmento'], $r['presentes'], $r['participantes_unicos']], $payload['segmentos'])
+            ),
+
+            new PainelGerencialSheet(
+                'Evolução Semestral',
+                ['Semestre', 'Eventos', 'Presentes', 'Avaliações'],
+                array_map(fn ($r) => [$r['semestre'], $r['eventos'], $r['presentes'], $r['avaliacoes']], $payload['evolucao_semestral'])
+            ),
+
+            new PainelGerencialSheet(
+                'Baixo Engajamento',
+                ['Município', 'Região', 'Previstas', 'Presentes', '% Realizado'],
+                array_map(fn ($r) => [$r['municipio'], $r['regiao'], $r['previstas'], $r['presentes'], $r['pct_realizado']], $payload['municipios_baixo_engajamento'])
+            ),
+
+            new PainelGerencialSheet(
+                'Sem Avaliação',
+                ['Ação', 'Momento', 'Município', 'Data'],
+                array_map(fn ($r) => [$r['acao'], $r['momento'], $r['municipio'], $r['dia']], $payload['eventos_sem_avaliacao'])
+            ),
+
+            new PainelGerencialSheet(
+                'Recorrência Ausência',
+                ['Participante', 'Município', 'Ausências'],
+                array_map(fn ($r) => [$r['participante'], $r['municipio'], $r['ausencias']], $payload['recorrencia_ausencia'])
+            ),
+        ];
+    }
+}

--- a/app/Exports/PainelGerencialSheet.php
+++ b/app/Exports/PainelGerencialSheet.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+
+/**
+ * Aba genérica do export do painel gerencial: título, cabeçalho e linhas.
+ */
+class PainelGerencialSheet implements FromArray, ShouldAutoSize, WithHeadings, WithTitle
+{
+    /**
+     * @param  array<int, string>  $headings
+     * @param  array<int, array<int, mixed>>  $rows
+     */
+    public function __construct(
+        private string $title,
+        private array $headings,
+        private array $rows,
+    ) {}
+
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function headings(): array
+    {
+        return $this->headings;
+    }
+
+    /**
+     * @return array<int, array<int, mixed>>
+     */
+    public function array(): array
+    {
+        return $this->rows;
+    }
+}

--- a/app/Http/Controllers/PainelGerencialController.php
+++ b/app/Http/Controllers/PainelGerencialController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Exports\PainelGerencialExport;
+use App\Models\Atividade;
+use App\Models\Evento;
+use App\Models\Municipio;
+use App\Models\Regiao;
+use App\Services\PainelGerencialService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Maatwebsite\Excel\Facades\Excel;
+use Spatie\LaravelPdf\Facades\Pdf;
+
+class PainelGerencialController extends Controller
+{
+    public function __construct(private PainelGerencialService $service) {}
+
+    public function index(Request $request)
+    {
+        $payload = $this->service->buildPayload($request);
+
+        $eventos = Evento::query()->orderBy('nome')->pluck('nome', 'id');
+        $regioes = Regiao::query()->orderBy('nome')->get();
+        $municipios = Municipio::query()->with('estado:id,sigla')->orderBy('nome')->get();
+        $momentos = Atividade::query()
+            ->select('descricao')
+            ->whereNotNull('descricao')
+            ->where('descricao', '!=', '')
+            ->distinct()
+            ->orderBy('descricao')
+            ->pluck('descricao');
+
+        return view('painel-gerencial.index', array_merge($payload, compact('eventos', 'regioes', 'municipios', 'momentos')));
+    }
+
+    public function dados(Request $request): JsonResponse
+    {
+        return response()->json($this->service->buildPayload($request));
+    }
+
+    public function exportar(Request $request)
+    {
+        $formato = $request->get('formato', 'xlsx');
+
+        if ($formato === 'pdf') {
+            ini_set('memory_limit', config('dashboard.pdf.memory_limit'));
+
+            $payload = $this->service->buildPayload($request);
+
+            // O header do macro é renderizado a width:100% (escala com a página),
+            // então a margem superior precisa acompanhar a proporção da imagem.
+            // A4 paisagem tem 297mm de largura. O rodapé tem largura fixa no macro,
+            // logo a margem inferior padrão (25mm) já o acomoda.
+            $marginTop = $this->brandImageMarginMm('images/Alfa-Eja Header.png', 297, 40);
+
+            return Pdf::view('painel-gerencial.pdf', $payload)
+                ->format('a4')
+                ->landscape()
+                ->withAlfaEjaBrand($marginTop, 10, 25, 10)
+                ->download('painel-gerencial-'.now()->format('Ymd_His').'.pdf');
+        }
+
+        return Excel::download(
+            new PainelGerencialExport($request),
+            'painel-gerencial-'.now()->format('Ymd_His').'.xlsx'
+        );
+    }
+
+    /**
+     * Calcula a margem (em mm) necessária para acomodar uma imagem de
+     * cabeçalho/rodapé que é renderizada a 100% da largura da página pelo
+     * Puppeteer. A altura renderizada = largura da página × (altura/largura da
+     * imagem); somamos uma folga de 3mm. Cai no fallback se a imagem não existir
+     * ou não puder ser lida, mantendo o comportamento correto para qualquer
+     * proporção de imagem.
+     */
+    private function brandImageMarginMm(string $relativePath, float $pageWidthMm, int $fallback): int
+    {
+        $path = public_path($relativePath);
+
+        if (! is_file($path)) {
+            return $fallback;
+        }
+
+        $dimensoes = @getimagesize($path);
+        if ($dimensoes === false || empty($dimensoes[0])) {
+            return $fallback;
+        }
+
+        [$largura, $altura] = $dimensoes;
+        $alturaMm = $pageWidthMm * ($altura / $largura);
+
+        return (int) ceil($alturaMm + 3);
+    }
+
+    public function momentos(Request $request): JsonResponse
+    {
+        $eventoId = $request->integer('evento_id');
+
+        $momentos = Atividade::query()
+            ->select('descricao')
+            ->when($eventoId, fn ($q) => $q->where('evento_id', $eventoId))
+            ->whereNotNull('descricao')
+            ->where('descricao', '!=', '')
+            ->distinct()
+            ->orderBy('descricao')
+            ->pluck('descricao');
+
+        $municipios = Municipio::query()
+            ->with('estado:id,sigla')
+            ->whereIn('id',
+                Atividade::query()
+                    ->select('municipio_id')
+                    ->when($eventoId, fn ($q) => $q->where('evento_id', $eventoId))
+                    ->whereNotNull('municipio_id')
+                    ->distinct()
+                    ->pluck('municipio_id')
+            )
+            ->orderBy('nome')
+            ->get(['id', 'nome', 'estado_id'])
+            ->map(fn ($m) => ['id' => $m->id, 'nome' => $m->nome_com_estado]);
+
+        return response()->json(['momentos' => $momentos, 'municipios' => $municipios]);
+    }
+}

--- a/app/Services/PainelGerencialService.php
+++ b/app/Services/PainelGerencialService.php
@@ -1,0 +1,465 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Agrega os quantitativos do painel gerencial (KPIs, metas por ação,
+ * participação por região, segmentos, evolução semestral e listas de
+ * acompanhamento). Centraliza a lógica consumida pela tela, pelo PDF e
+ * pelo export XLSX.
+ */
+class PainelGerencialService
+{
+    /**
+     * Monta o payload completo do painel aplicando os filtros do request.
+     *
+     * @return array{filtros: array, kpis: array, metas_por_acao: array, participacao_por_regiao: array, segmentos: array, evolucao_semestral: array, municipios_baixo_engajamento: array, eventos_sem_avaliacao: array, recorrencia_ausencia: array}
+     */
+    public function buildPayload(Request $request): array
+    {
+        $filtros = $this->extractFilters($request);
+
+        return [
+            'filtros' => $this->describeFilters($filtros),
+            'kpis' => $this->kpis($filtros),
+            'metas_por_acao' => $this->metasPorAcao($filtros),
+            'participacao_por_regiao' => $this->participacaoPorRegiao($filtros),
+            'segmentos' => $this->segmentos($filtros),
+            'evolucao_semestral' => $this->evolucaoSemestral($filtros),
+            'municipios_baixo_engajamento' => $this->municipiosBaixoEngajamento($filtros),
+            'eventos_sem_avaliacao' => $this->eventosSemAvaliacao($filtros),
+            'recorrencia_ausencia' => $this->recorrenciaAusencia($filtros),
+        ];
+    }
+
+    /**
+     * @return array{evento_id: ?int, municipio_id: ?int, regiao_id: ?int, de: ?Carbon, ate: ?Carbon, periodo: string}
+     */
+    private function extractFilters(Request $request): array
+    {
+        return [
+            'evento_id' => $request->integer('evento_id') ?: null,
+            'municipio_id' => $request->integer('municipio_id') ?: null,
+            'regiao_id' => $request->integer('regiao_id') ?: null,
+            'de' => $request->date('de'),
+            'ate' => $request->date('ate'),
+            'periodo' => (string) $request->get('periodo', ''),
+        ];
+    }
+
+    /**
+     * Aplica os filtros comuns a uma query que já contém a tabela `atividades`
+     * (e os joins de eventos/municipios/estados/regiaos quando necessário).
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function applyAtividadeFilters(Builder $query, array $f, bool $hasRegiaoJoin = false): Builder
+    {
+        $query->when($f['evento_id'], fn ($q) => $q->where('atividades.evento_id', $f['evento_id']));
+        $query->when($f['municipio_id'], fn ($q) => $q->where('atividades.municipio_id', $f['municipio_id']));
+        if ($hasRegiaoJoin) {
+            $query->when($f['regiao_id'], fn ($q) => $q->where('regiaos.id', $f['regiao_id']));
+        }
+
+        $query->when($f['de'] && $f['ate'], fn ($q) => $q->whereBetween('atividades.dia', [$f['de'], $f['ate']]));
+        $query->when($f['de'] && ! $f['ate'], fn ($q) => $q->where('atividades.dia', '>=', $f['de']));
+        $query->when(! $f['de'] && $f['ate'], fn ($q) => $q->where('atividades.dia', '<=', $f['ate']));
+
+        $query->when($f['periodo'] === 'manha', fn ($q) => $q->whereRaw("CAST(atividades.hora_inicio AS time) < '12:00:00'"));
+        $query->when($f['periodo'] === 'tarde', fn ($q) => $q->whereRaw("CAST(atividades.hora_inicio AS time) >= '12:00:00'")
+            ->whereRaw("CAST(atividades.hora_inicio AS time) < '18:00:00'"));
+        $query->when($f['periodo'] === 'noite', fn ($q) => $q->whereRaw("CAST(atividades.hora_inicio AS time) >= '18:00:00'"));
+
+        return $query;
+    }
+
+    /**
+     * Base de atividades válidas (não deletadas e vinculadas a um evento),
+     * com joins geográficos, já filtrada.
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function baseAtividades(array $f): Builder
+    {
+        $query = DB::table('atividades')
+            ->leftJoin('eventos', 'eventos.id', '=', 'atividades.evento_id')
+            ->leftJoin('municipios', 'municipios.id', '=', 'atividades.municipio_id')
+            ->leftJoin('estados', 'estados.id', '=', 'municipios.estado_id')
+            ->leftJoin('regiaos', 'regiaos.id', '=', 'estados.regiao_id')
+            ->whereNull('atividades.deleted_at')
+            ->whereNotNull('atividades.evento_id');
+
+        return $this->applyAtividadeFilters($query, $f, hasRegiaoJoin: true);
+    }
+
+    /**
+     * Presenças com status 'presente' das atividades em escopo, já filtradas,
+     * com os joins até participante/usuário.
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function basePresencas(array $f, string $status = 'presente'): Builder
+    {
+        $query = DB::table('presencas')
+            ->join('atividades', 'presencas.atividade_id', '=', 'atividades.id')
+            ->join('inscricaos', 'presencas.inscricao_id', '=', 'inscricaos.id')
+            ->join('participantes', 'inscricaos.participante_id', '=', 'participantes.id')
+            ->leftJoin('municipios', 'municipios.id', '=', 'atividades.municipio_id')
+            ->leftJoin('estados', 'estados.id', '=', 'municipios.estado_id')
+            ->leftJoin('regiaos', 'regiaos.id', '=', 'estados.regiao_id')
+            ->whereNull('atividades.deleted_at')
+            ->whereNotNull('atividades.evento_id')
+            ->when($status !== '', fn ($q) => $q->where('presencas.status', $status));
+
+        return $this->applyAtividadeFilters($query, $f, hasRegiaoJoin: true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $f
+     */
+    private function kpis(array $f): array
+    {
+        $municipiosAtivos = (clone $this->baseAtividades($f))
+            ->whereNotNull('atividades.municipio_id')
+            ->distinct()
+            ->count('atividades.municipio_id');
+
+        $eventosRealizados = (clone $this->baseAtividades($f))
+            ->distinct()
+            ->count('atividades.evento_id');
+
+        // Participantes: totais = presenças; únicos = participantes distintos.
+        $participantesTotais = (clone $this->basePresencas($f))->count();
+        $participantesUnicos = (clone $this->basePresencas($f))->distinct()->count('participantes.id');
+
+        $avaliacoesRespondidas = (clone $this->basePresencas($f))
+            ->where('presencas.avaliacao_respondida', true)
+            ->count();
+
+        $certificadosEmitidos = (clone $this->basePresencas($f))
+            ->where('presencas.certificado_emitido', true)
+            ->count();
+
+        // Pendências de documentação: participantes presentes sem CPF/telefone.
+        $pendencias = (clone $this->basePresencas($f))
+            ->where(function ($q) {
+                $q->whereNull('participantes.cpf')->orWhere('participantes.cpf', '')
+                    ->orWhereNull('participantes.telefone')->orWhere('participantes.telefone', '');
+            })
+            ->distinct()
+            ->count('participantes.id');
+
+        // Horas cumpridas por modalidade (carga_horaria em minutos → horas).
+        $buckets = config('painel-gerencial.modalidade_buckets');
+        $horasRows = (clone $this->baseAtividades($f))
+            ->selectRaw('eventos.modalidade, SUM(atividades.carga_horaria) as minutos')
+            ->groupBy('eventos.modalidade')
+            ->get();
+
+        $horas = ['presencial' => 0.0, 'ead' => 0.0, 'hibrido' => 0.0, 'outros' => 0.0];
+        foreach ($horasRows as $row) {
+            $bucket = $buckets[$row->modalidade] ?? 'outros';
+            $horas[$bucket] += round(((int) $row->minutos) / 60, 1);
+        }
+
+        return [
+            'municipios_ativos' => $municipiosAtivos,
+            'participantes_totais' => $participantesTotais,
+            'participantes_unicos' => $participantesUnicos,
+            'eventos_realizados' => $eventosRealizados,
+            'horas_presenciais' => round($horas['presencial'], 1),
+            'horas_ead' => round($horas['ead'], 1),
+            'horas_hibrido' => round($horas['hibrido'], 1),
+            'certificados_emitidos' => $certificadosEmitidos,
+            'avaliacoes_respondidas' => $avaliacoesRespondidas,
+            'pendencias_documentacao' => $pendencias,
+        ];
+    }
+
+    /**
+     * Previstas × inscritos × presentes × avaliações por Ação Pedagógica.
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function metasPorAcao(array $f): array
+    {
+        // Previstas (soma de publico_esperado das atividades em escopo) por evento.
+        $previstas = (clone $this->baseAtividades($f))
+            ->selectRaw('atividades.evento_id, eventos.nome as evento_nome, SUM(atividades.publico_esperado) as previstas')
+            ->groupBy('atividades.evento_id', 'eventos.nome')
+            ->get()
+            ->keyBy('evento_id');
+
+        // Inscritos distintos por evento (vinculados às atividades em escopo).
+        $inscritos = (clone $this->baseAtividades($f))
+            ->join('inscricaos', 'inscricaos.atividade_id', '=', 'atividades.id')
+            ->selectRaw('atividades.evento_id, COUNT(DISTINCT inscricaos.participante_id) as inscritos')
+            ->groupBy('atividades.evento_id')
+            ->pluck('inscritos', 'evento_id');
+
+        // Presentes e avaliações por evento.
+        $presencas = (clone $this->basePresencas($f))
+            ->selectRaw('atividades.evento_id')
+            ->selectRaw('COUNT(*) as presentes')
+            ->selectRaw('COUNT(CASE WHEN presencas.avaliacao_respondida = true THEN 1 END) as avaliacoes')
+            ->groupBy('atividades.evento_id')
+            ->get()
+            ->keyBy('evento_id');
+
+        $rows = [];
+        foreach ($previstas as $eventoId => $prev) {
+            $prevQtd = (int) $prev->previstas;
+            $presentes = (int) ($presencas->get($eventoId)->presentes ?? 0);
+            $avaliacoes = (int) ($presencas->get($eventoId)->avaliacoes ?? 0);
+
+            $rows[] = [
+                'evento_id' => $eventoId,
+                'acao' => $prev->evento_nome,
+                'previstas' => $prevQtd,
+                'inscritos' => (int) ($inscritos[$eventoId] ?? 0),
+                'presentes' => $presentes,
+                'avaliacoes' => $avaliacoes,
+                'pct_realizado' => $this->pct($presentes, $prevQtd),
+            ];
+        }
+
+        usort($rows, fn ($a, $b) => strcmp((string) $a['acao'], (string) $b['acao']));
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string, mixed>  $f
+     */
+    private function participacaoPorRegiao(array $f): array
+    {
+        $previstas = (clone $this->baseAtividades($f))
+            ->selectRaw("COALESCE(regiaos.nome, 'Sem região') as regiao, SUM(atividades.publico_esperado) as previstas")
+            ->groupBy('regiaos.nome')
+            ->pluck('previstas', 'regiao');
+
+        $presentes = (clone $this->basePresencas($f))
+            ->selectRaw("COALESCE(regiaos.nome, 'Sem região') as regiao, COUNT(*) as presentes")
+            ->groupBy('regiaos.nome')
+            ->pluck('presentes', 'regiao');
+
+        $regioes = $previstas->keys()->merge($presentes->keys())->unique()->sort()->values();
+
+        return $regioes->map(function ($regiao) use ($previstas, $presentes) {
+            $prev = (int) ($previstas[$regiao] ?? 0);
+            $pres = (int) ($presentes[$regiao] ?? 0);
+
+            return [
+                'regiao' => $regiao,
+                'previstas' => $prev,
+                'presentes' => $pres,
+                'pct_realizado' => $this->pct($pres, $prev),
+            ];
+        })->all();
+    }
+
+    /**
+     * Comparação entre segmentos (tag do participante).
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function segmentos(array $f): array
+    {
+        $rows = (clone $this->basePresencas($f))
+            ->selectRaw("COALESCE(NULLIF(participantes.tag, ''), 'Sem segmento') as segmento")
+            ->selectRaw('COUNT(*) as presentes')
+            ->selectRaw('COUNT(DISTINCT participantes.id) as participantes_unicos')
+            ->groupBy('participantes.tag')
+            ->orderByDesc('presentes')
+            ->get();
+
+        return $rows->map(fn ($r) => [
+            'segmento' => $r->segmento,
+            'presentes' => (int) $r->presentes,
+            'participantes_unicos' => (int) $r->participantes_unicos,
+        ])->all();
+    }
+
+    /**
+     * Evolução semestral derivada da data da atividade (S1 = jan–jun).
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function evolucaoSemestral(array $f): array
+    {
+        $semestreExpr = "(EXTRACT(YEAR FROM atividades.dia)::int || '-S' || (CASE WHEN EXTRACT(MONTH FROM atividades.dia) <= 6 THEN 1 ELSE 2 END))";
+
+        $eventos = (clone $this->baseAtividades($f))
+            ->selectRaw("$semestreExpr as semestre, COUNT(DISTINCT atividades.evento_id) as eventos")
+            ->whereNotNull('atividades.dia')
+            ->groupByRaw($semestreExpr)
+            ->pluck('eventos', 'semestre');
+
+        $presencas = (clone $this->basePresencas($f))
+            ->selectRaw("$semestreExpr as semestre")
+            ->selectRaw('COUNT(*) as presentes')
+            ->selectRaw('COUNT(CASE WHEN presencas.avaliacao_respondida = true THEN 1 END) as avaliacoes')
+            ->whereNotNull('atividades.dia')
+            ->groupByRaw($semestreExpr)
+            ->get()
+            ->keyBy('semestre');
+
+        $semestres = $eventos->keys()->merge($presencas->keys())->unique()->sort()->values();
+
+        return $semestres->map(fn ($s) => [
+            'semestre' => $s,
+            'eventos' => (int) ($eventos[$s] ?? 0),
+            'presentes' => (int) ($presencas->get($s)->presentes ?? 0),
+            'avaliacoes' => (int) ($presencas->get($s)->avaliacoes ?? 0),
+        ])->all();
+    }
+
+    /**
+     * Municípios cujo realizado (presentes/previstos) está abaixo do limite.
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function municipiosBaixoEngajamento(array $f): array
+    {
+        $limite = (float) config('painel-gerencial.engajamento_minimo_pct');
+
+        $previstas = (clone $this->baseAtividades($f))
+            ->selectRaw('atividades.municipio_id, municipios.nome as municipio_nome, regiaos.nome as regiao, SUM(atividades.publico_esperado) as previstas')
+            ->whereNotNull('atividades.municipio_id')
+            ->groupBy('atividades.municipio_id', 'municipios.nome', 'regiaos.nome')
+            ->get()
+            ->keyBy('municipio_id');
+
+        $presentes = (clone $this->basePresencas($f))
+            ->selectRaw('atividades.municipio_id, COUNT(*) as presentes')
+            ->whereNotNull('atividades.municipio_id')
+            ->groupBy('atividades.municipio_id')
+            ->pluck('presentes', 'municipio_id');
+
+        $rows = [];
+        foreach ($previstas as $municipioId => $p) {
+            $prev = (int) $p->previstas;
+            $pres = (int) ($presentes[$municipioId] ?? 0);
+            $pct = $this->pct($pres, $prev);
+
+            if ($prev > 0 && $pct < $limite) {
+                $rows[] = [
+                    'municipio' => $p->municipio_nome,
+                    'regiao' => $p->regiao ?? 'Sem região',
+                    'previstas' => $prev,
+                    'presentes' => $pres,
+                    'pct_realizado' => $pct,
+                ];
+            }
+        }
+
+        usort($rows, fn ($a, $b) => $a['pct_realizado'] <=> $b['pct_realizado']);
+
+        return $rows;
+    }
+
+    /**
+     * Atividades já realizadas (data passada) sem nenhuma avaliação respondida.
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function eventosSemAvaliacao(array $f): array
+    {
+        $rows = (clone $this->baseAtividades($f))
+            ->selectRaw('atividades.id, atividades.descricao, atividades.dia, eventos.nome as evento_nome, municipios.nome as municipio_nome')
+            ->selectRaw('(SELECT COUNT(*) FROM presencas WHERE presencas.atividade_id = atividades.id AND presencas.status = \'presente\' AND presencas.avaliacao_respondida = true) as avaliacoes')
+            ->whereDate('atividades.dia', '<', Carbon::today())
+            ->get()
+            ->filter(fn ($r) => (int) $r->avaliacoes === 0)
+            ->values();
+
+        return $rows->map(fn ($r) => [
+            'acao' => $r->evento_nome,
+            'momento' => $r->descricao,
+            'municipio' => $r->municipio_nome,
+            'dia' => $r->dia,
+        ])->all();
+    }
+
+    /**
+     * Participantes com N+ ausências (inscritos que não tiveram presença
+     * 'presente' na atividade correspondente).
+     *
+     * @param  array<string, mixed>  $f
+     */
+    private function recorrenciaAusencia(array $f): array
+    {
+        $minimo = (int) config('painel-gerencial.recorrencia_ausencia_minima');
+
+        $query = DB::table('inscricaos')
+            ->join('atividades', 'inscricaos.atividade_id', '=', 'atividades.id')
+            ->join('participantes', 'inscricaos.participante_id', '=', 'participantes.id')
+            ->join('users', 'users.id', '=', 'participantes.user_id')
+            ->leftJoin('municipios', 'municipios.id', '=', 'atividades.municipio_id')
+            ->leftJoin('estados', 'estados.id', '=', 'municipios.estado_id')
+            ->leftJoin('regiaos', 'regiaos.id', '=', 'estados.regiao_id')
+            ->leftJoin('presencas', function ($join) {
+                $join->on('presencas.inscricao_id', '=', 'inscricaos.id')
+                    ->where('presencas.status', '=', 'presente');
+            })
+            ->whereNull('atividades.deleted_at')
+            ->whereNotNull('atividades.evento_id')
+            ->whereNull('presencas.id');
+
+        $this->applyAtividadeFilters($query, $f, hasRegiaoJoin: true);
+
+        $rows = $query
+            ->selectRaw('participantes.id, users.name as nome, municipios.nome as municipio_nome, COUNT(*) as ausencias')
+            ->groupBy('participantes.id', 'users.name', 'municipios.nome')
+            ->havingRaw('COUNT(*) >= ?', [$minimo])
+            ->orderByRaw('COUNT(*) DESC')
+            ->get();
+
+        return $rows->map(fn ($r) => [
+            'participante' => $r->nome,
+            'municipio' => $r->municipio_nome,
+            'ausencias' => (int) $r->ausencias,
+        ])->all();
+    }
+
+    private function pct(int $n, int $total): float
+    {
+        return $total > 0 ? round($n / $total * 100, 1) : 0.0;
+    }
+
+    /**
+     * Resumo legível dos filtros aplicados (para cabeçalhos de PDF/XLSX).
+     *
+     * @param  array<string, mixed>  $f
+     * @return array<string, string>
+     */
+    private function describeFilters(array $f): array
+    {
+        $resumo = [];
+
+        if ($f['evento_id']) {
+            $resumo['Ação'] = (string) DB::table('eventos')->where('id', $f['evento_id'])->value('nome');
+        }
+        if ($f['municipio_id']) {
+            $resumo['Município'] = (string) DB::table('municipios')->where('id', $f['municipio_id'])->value('nome');
+        }
+        if ($f['regiao_id']) {
+            $resumo['Região'] = (string) DB::table('regiaos')->where('id', $f['regiao_id'])->value('nome');
+        }
+        if ($f['de'] || $f['ate']) {
+            $de = $f['de'] ? $f['de']->format('d/m/Y') : '...';
+            $ate = $f['ate'] ? $f['ate']->format('d/m/Y') : '...';
+            $resumo['Período'] = "$de a $ate";
+        }
+        if ($f['periodo']) {
+            $resumo['Turno'] = ucfirst($f['periodo']);
+        }
+
+        return $resumo;
+    }
+}

--- a/config/painel-gerencial.php
+++ b/config/painel-gerencial.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Limiares do Painel Gerencial
+    |--------------------------------------------------------------------------
+    |
+    | Parâmetros que definem os recortes de acompanhamento exibidos no painel
+    | gerencial de quantitativos. Mantidos em config (lendo env apenas aqui)
+    | para que os call sites usem config(...) sem 2º argumento.
+    |
+    */
+
+    // Percentual mínimo de realizado (presentes/previstos) abaixo do qual um
+    // município é considerado de "baixo engajamento".
+    'engajamento_minimo_pct' => (float) env('PAINEL_ENGAJAMENTO_MINIMO_PCT', 50),
+
+    // Número mínimo de ausências para um participante entrar na lista de
+    // "recorrência de ausência".
+    'recorrencia_ausencia_minima' => (int) env('PAINEL_RECORRENCIA_AUSENCIA_MINIMA', 2),
+
+    // Mapeamento dos valores da coluna eventos.modalidade para os baldes de horas.
+    'modalidade_buckets' => [
+        'Presencial' => 'presencial',
+        'Online' => 'ead',
+        'Híbrido' => 'hibrido',
+    ],
+];

--- a/resources/views/layouts/partials/admin-sidebar.blade.php
+++ b/resources/views/layouts/partials/admin-sidebar.blade.php
@@ -123,7 +123,7 @@
           </div>
         </div>
 
-        @php($relatoriosOpen = request()->routeIs('avaliacao-atividade.*') || request()->routeIs('relatorio-quantitativo.*'))
+        @php($relatoriosOpen = request()->routeIs('avaliacao-atividade.*') || request()->routeIs('relatorio-quantitativo.*') || request()->routeIs('painel-gerencial.*'))
         <div class="accordion-item">
           <h2 class="accordion-header" id="headingRelatorios">
             <button class="accordion-button admin-accordion-button {{ $relatoriosOpen ? '' : 'collapsed' }}" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarRelatorios" aria-expanded="{{ $relatoriosOpen ? 'true' : 'false' }}" aria-controls="sidebarRelatorios">
@@ -142,6 +142,9 @@
               </a>
               <a class="admin-nav-link {{ request()->routeIs('relatorio-quantitativo.*') ? 'active' : '' }}" href="{{ route('relatorio-quantitativo.index') }}">
                 Relatório Quantitativo
+              </a>
+              <a class="admin-nav-link {{ request()->routeIs('painel-gerencial.*') ? 'active' : '' }}" href="{{ route('painel-gerencial.index') }}">
+                Painel Gerencial
               </a>
             </div>
           </div>

--- a/resources/views/painel-gerencial/index.blade.php
+++ b/resources/views/painel-gerencial/index.blade.php
@@ -1,0 +1,311 @@
+@extends('layouts.app')
+
+@section('content')
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<style>
+    /* Rola o corpo da tabela mantendo o cabeçalho fixo no topo do card. */
+    .painel-scroll { overflow-y: auto; }
+    .painel-scroll thead th {
+        position: sticky;
+        top: 0;
+        background: #fff;
+        z-index: 1;
+        box-shadow: inset 0 -1px 0 #dee2e6;
+    }
+</style>
+<div class="container py-4">
+
+    <div class="d-flex flex-wrap justify-content-between align-items-start mb-3 gap-2">
+        <div>
+            <p class="text-uppercase small text-muted mb-1">Relatórios</p>
+            <h1 class="h4 mb-0">Painel Gerencial de Quantitativos</h1>
+            <p class="text-muted small mb-0">Quadro de referência: público esperado × inscritos × presentes × avaliações, por Ação Pedagógica.</p>
+        </div>
+        <div class="d-flex gap-2">
+            <a href="{{ route('painel-gerencial.exportar') }}?{{ http_build_query(array_merge(request()->query(), ['formato' => 'pdf'])) }}" class="btn btn-sm btn-outline-danger" title="Exportar como PDF">
+                <i class="bi bi-filetype-pdf"></i> PDF
+            </a>
+            <a href="{{ route('painel-gerencial.exportar') }}?{{ http_build_query(array_merge(request()->query(), ['formato' => 'xlsx'])) }}" class="btn btn-sm btn-outline-success" title="Exportar como Excel">
+                <i class="bi bi-file-earmark-spreadsheet"></i> Excel
+            </a>
+        </div>
+    </div>
+
+    {{-- Filtros --}}
+    <div class="card shadow-sm mb-4">
+        <div class="card-body py-3">
+            <form method="GET" action="{{ route('painel-gerencial.index') }}" class="row g-2 align-items-end">
+                <div class="col-md-3 col-lg-3">
+                    <label class="form-label mb-1 small fw-semibold">Ação</label>
+                    <select name="evento_id" id="filter-evento" class="form-select form-select-sm">
+                        <option value="">Todas</option>
+                        @foreach($eventos as $id => $nome)
+                            <option value="{{ $id }}" @selected(request('evento_id') == $id)>{{ $nome }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Região</label>
+                    <select name="regiao_id" class="form-select form-select-sm">
+                        <option value="">Todas</option>
+                        @foreach($regioes as $regiao)
+                            <option value="{{ $regiao->id }}" @selected(request('regiao_id') == $regiao->id)>{{ $regiao->nome }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3 col-lg-3">
+                    <label class="form-label mb-1 small fw-semibold">Município</label>
+                    <select name="municipio_id" id="filter-municipio" class="form-select form-select-sm">
+                        <option value="">Todos</option>
+                        @foreach($municipios as $municipio)
+                            <option value="{{ $municipio->id }}" @selected(request('municipio_id') == $municipio->id)>{{ $municipio->nome_com_estado }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Intervalo</label>
+                    <input type="text" id="filter-daterange" class="form-control form-control-sm" placeholder="De ... até">
+                    <input type="hidden" name="de" id="filter-de" value="{{ request('de') }}">
+                    <input type="hidden" name="ate" id="filter-ate" value="{{ request('ate') }}">
+                </div>
+                <div class="col-md-2 col-lg-2">
+                    <label class="form-label mb-1 small fw-semibold">Período</label>
+                    <select name="periodo" class="form-select form-select-sm">
+                        <option value="">Todos</option>
+                        <option value="manha" @selected(request('periodo') == 'manha')>Manhã</option>
+                        <option value="tarde" @selected(request('periodo') == 'tarde')>Tarde</option>
+                        <option value="noite" @selected(request('periodo') == 'noite')>Noite</option>
+                    </select>
+                </div>
+                <div class="col-auto d-flex gap-2">
+                    <button type="submit" class="btn btn-sm text-white" style="background-color:#421944;">Filtrar</button>
+                    <a href="{{ route('painel-gerencial.index') }}" class="btn btn-outline-secondary btn-sm">Limpar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {{-- KPIs --}}
+    @php
+        $cards = [
+            ['Municípios ativos', $kpis['municipios_ativos'], 'bi-geo-alt'],
+            ['Participantes totais', $kpis['participantes_totais'], 'bi-people'],
+            ['Participantes únicos', $kpis['participantes_unicos'], 'bi-person-check'],
+            ['Eventos realizados', $kpis['eventos_realizados'], 'bi-calendar-event'],
+            ['Horas presenciais', $kpis['horas_presenciais'], 'bi-building'],
+            ['Horas EaD', $kpis['horas_ead'], 'bi-laptop'],
+            ['Certificados emitidos', $kpis['certificados_emitidos'], 'bi-award'],
+            ['Avaliações respondidas', $kpis['avaliacoes_respondidas'], 'bi-clipboard-check'],
+            ['Pendências de documentação', $kpis['pendencias_documentacao'], 'bi-exclamation-triangle'],
+        ];
+    @endphp
+    <div class="row g-3 mb-4">
+        @foreach($cards as [$label, $valor, $icon])
+            <div class="col-6 col-md-4 col-lg-3 col-xl-2">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body py-3">
+                        <div class="text-muted small mb-1"><i class="bi {{ $icon }}"></i> {{ $label }}</div>
+                        <div class="h4 mb-0">{{ is_float($valor) ? number_format($valor, 1, ',', '.') : number_format($valor, 0, ',', '.') }}</div>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    {{-- Gráficos --}}
+    <div class="row g-3 mb-4">
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6">Metas previstas × realizadas (por ação)</h2>
+                <div style="position:relative;height:300px"><canvas id="chartMetas"></canvas></div>
+            </div></div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6">Participação por região</h2>
+                <div style="position:relative;height:300px"><canvas id="chartRegiao"></canvas></div>
+            </div></div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6">Comparação entre segmentos</h2>
+                <div style="position:relative;height:300px"><canvas id="chartSegmentos"></canvas></div>
+            </div></div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6">Evolução semestral</h2>
+                <div style="position:relative;height:300px"><canvas id="chartEvolucao"></canvas></div>
+            </div></div>
+        </div>
+    </div>
+
+    {{-- Metas por ação (tabela) --}}
+    <div class="card shadow-sm mb-4"><div class="card-body">
+        <h2 class="h6 mb-3">Metas por Ação Pedagógica</h2>
+        <div class="table-responsive painel-scroll" style="max-height: 440px;">
+            <table class="table table-sm table-hover align-middle mb-0">
+                <thead><tr>
+                    <th>Ação</th><th class="text-end">Previstas</th><th class="text-end">Inscritos</th>
+                    <th class="text-end">Presentes</th><th class="text-end">Avaliações</th><th class="text-end">% Realizado</th>
+                </tr></thead>
+                <tbody>
+                    @forelse($metas_por_acao as $r)
+                        <tr>
+                            <td>{{ $r['acao'] }}</td>
+                            <td class="text-end">{{ $r['previstas'] }}</td>
+                            <td class="text-end">{{ $r['inscritos'] }}</td>
+                            <td class="text-end">{{ $r['presentes'] }}</td>
+                            <td class="text-end">{{ $r['avaliacoes'] }}</td>
+                            <td class="text-end">{{ number_format($r['pct_realizado'], 1, ',', '.') }}%</td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="6" class="text-center text-muted py-3">Sem dados para os filtros aplicados.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div></div>
+
+    {{-- Listas de acompanhamento --}}
+    <div class="row g-3">
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6 mb-3">Municípios com baixo engajamento</h2>
+                <div class="table-responsive painel-scroll" style="max-height: 340px;"><table class="table table-sm mb-0">
+                    <thead><tr><th>Município</th><th class="text-end">% Realizado</th></tr></thead>
+                    <tbody>
+                        @forelse($municipios_baixo_engajamento as $r)
+                            <tr><td>{{ $r['municipio'] }} <span class="text-muted small">({{ $r['regiao'] }})</span></td><td class="text-end text-danger">{{ number_format($r['pct_realizado'], 1, ',', '.') }}%</td></tr>
+                        @empty
+                            <tr><td colspan="2" class="text-center text-muted py-3">Nenhum.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table></div>
+            </div></div>
+        </div>
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6 mb-3">Eventos sem avaliação registrada</h2>
+                <div class="table-responsive painel-scroll" style="max-height: 340px;"><table class="table table-sm mb-0">
+                    <thead><tr><th>Ação / Momento</th><th>Município</th></tr></thead>
+                    <tbody>
+                        @forelse($eventos_sem_avaliacao as $r)
+                            <tr><td>{{ $r['acao'] }}<br><span class="text-muted small">{{ $r['momento'] }}</span></td><td>{{ $r['municipio'] }}</td></tr>
+                        @empty
+                            <tr><td colspan="2" class="text-center text-muted py-3">Nenhum.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table></div>
+            </div></div>
+        </div>
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100"><div class="card-body">
+                <h2 class="h6 mb-3">Participantes com recorrência de ausência</h2>
+                <div class="table-responsive painel-scroll" style="max-height: 340px;"><table class="table table-sm mb-0">
+                    <thead><tr><th>Participante</th><th class="text-end">Ausências</th></tr></thead>
+                    <tbody>
+                        @forelse($recorrencia_ausencia as $r)
+                            <tr><td>{{ $r['participante'] }} <span class="text-muted small">({{ $r['municipio'] }})</span></td><td class="text-end">{{ $r['ausencias'] }}</td></tr>
+                        @empty
+                            <tr><td colspan="2" class="text-center text-muted py-3">Nenhum.</td></tr>
+                        @endforelse
+                    </tbody>
+                </table></div>
+            </div></div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/plugins/rangePlugin.js"></script>
+<script>
+(function () {
+    const metas      = @json($metas_por_acao);
+    const regioes    = @json($participacao_por_regiao);
+    const segmentos  = @json($segmentos);
+    const evolucao   = @json($evolucao_semestral);
+    const cor = '#421944';
+    const cor2 = '#b07cb3';
+
+    new Chart(document.getElementById('chartMetas'), {
+        type: 'bar',
+        data: {
+            labels: metas.map(m => m.acao),
+            datasets: [
+                { label: 'Previstas', data: metas.map(m => m.previstas), backgroundColor: cor2 },
+                { label: 'Presentes', data: metas.map(m => m.presentes), backgroundColor: cor },
+            ],
+        },
+        options: { maintainAspectRatio: false, responsive: true, plugins: { legend: { position: 'bottom' } } },
+    });
+
+    new Chart(document.getElementById('chartRegiao'), {
+        type: 'bar',
+        data: {
+            labels: regioes.map(r => r.regiao),
+            datasets: [
+                { label: 'Previstas', data: regioes.map(r => r.previstas), backgroundColor: cor2 },
+                { label: 'Presentes', data: regioes.map(r => r.presentes), backgroundColor: cor },
+            ],
+        },
+        options: { maintainAspectRatio: false, responsive: true, plugins: { legend: { position: 'bottom' } } },
+    });
+
+    new Chart(document.getElementById('chartSegmentos'), {
+        type: 'doughnut',
+        data: {
+            labels: segmentos.map(s => s.segmento),
+            datasets: [{ data: segmentos.map(s => s.presentes), backgroundColor: ['#421944', '#b07cb3', '#e8daea', '#8a5a8c', '#cbb0cc'] }],
+        },
+        options: { maintainAspectRatio: false, responsive: true, plugins: { legend: { position: 'bottom' } } },
+    });
+
+    new Chart(document.getElementById('chartEvolucao'), {
+        type: 'line',
+        data: {
+            labels: evolucao.map(e => e.semestre),
+            datasets: [
+                { label: 'Presentes', data: evolucao.map(e => e.presentes), borderColor: cor, backgroundColor: 'rgba(66,25,68,0.15)', fill: true },
+                { label: 'Avaliações', data: evolucao.map(e => e.avaliacoes), borderColor: cor2, backgroundColor: 'rgba(176,124,179,0.15)', fill: true },
+            ],
+        },
+        options: { maintainAspectRatio: false, responsive: true, plugins: { legend: { position: 'bottom' } } },
+    });
+
+    // Flatpickr range
+    const deInput = document.getElementById('filter-de');
+    const ateInput = document.getElementById('filter-ate');
+    flatpickr(document.getElementById('filter-daterange'), {
+        mode: 'range', dateFormat: 'Y-m-d', locale: { rangeSeparator: ' até ' },
+        defaultDate: [deInput.value, ateInput.value].filter(Boolean),
+        onChange: function (selectedDates) {
+            deInput.value  = selectedDates[0] ? flatpickr.formatDate(selectedDates[0], 'Y-m-d') : '';
+            ateInput.value = selectedDates[1] ? flatpickr.formatDate(selectedDates[1], 'Y-m-d') : '';
+        },
+    });
+
+    // Cascata: ao trocar a ação, recarrega municípios
+    const eventoSelect = document.getElementById('filter-evento');
+    const municipioSelect = document.getElementById('filter-municipio');
+    if (eventoSelect) {
+        eventoSelect.addEventListener('change', function () {
+            const url = '{{ route('painel-gerencial.momentos') }}?evento_id=' + (this.value || '');
+            fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+                .then(r => r.json())
+                .then(data => {
+                    const atual = municipioSelect.value;
+                    municipioSelect.innerHTML = '<option value="">Todos</option>';
+                    data.municipios.forEach(m => {
+                        const opt = document.createElement('option');
+                        opt.value = m.id; opt.textContent = m.nome;
+                        if (String(m.id) === atual) opt.selected = true;
+                        municipioSelect.appendChild(opt);
+                    });
+                });
+        });
+    }
+})();
+</script>
+@endsection

--- a/resources/views/painel-gerencial/pdf.blade.php
+++ b/resources/views/painel-gerencial/pdf.blade.php
@@ -1,0 +1,149 @@
+@extends('layouts.pdf-alfa-eja-landscape')
+
+@section('title', 'Painel Gerencial de Quantitativos')
+
+@section('styles')
+    /* Conteúdo longo / multipágina: sobrescreve o body centralizado do layout. */
+    body { display: block; height: auto; font-size: 9px; color: #222; }
+    h1 { font-size: 14px; color: #421944; margin-bottom: 2px; }
+    h2 { font-size: 11px; color: #421944; margin: 10px 0 4px; }
+    .sub { font-size: 8px; color: #666; margin-bottom: 6px; }
+    .filtros { font-size: 8px; color: #444; margin-bottom: 8px; }
+    .filtros span { display: inline-block; margin-right: 10px; }
+    th, td { border: 1px solid #ccc; padding: 3px 5px; text-align: left; }
+    th { background: #e8daea; color: #421944; font-weight: 700; }
+    table { margin-bottom: 6px; }
+    td.num, th.num { text-align: right; }
+    .kpis td { width: 25%; }
+    .kpis .label { color: #666; font-size: 8px; }
+    .kpis .valor { font-size: 13px; font-weight: 700; color: #421944; }
+    .vazio { color: #888; font-style: italic; }
+@endsection
+
+@section('content')
+    <h1>Painel Gerencial de Quantitativos</h1>
+    <div class="sub">Alfa-EJA — gerado em {{ now()->format('d/m/Y H:i') }}</div>
+
+    @if(!empty($filtros))
+        <div class="filtros">
+            <strong>Filtros:</strong>
+            @foreach($filtros as $rotulo => $valor)
+                <span>{{ $rotulo }}: {{ $valor }}</span>
+            @endforeach
+        </div>
+    @endif
+
+    <h2>Resumo</h2>
+    <table class="kpis">
+        <tr>
+            <td><div class="label">Municípios ativos</div><div class="valor">{{ $kpis['municipios_ativos'] }}</div></td>
+            <td><div class="label">Participantes totais</div><div class="valor">{{ $kpis['participantes_totais'] }}</div></td>
+            <td><div class="label">Participantes únicos</div><div class="valor">{{ $kpis['participantes_unicos'] }}</div></td>
+            <td><div class="label">Eventos realizados</div><div class="valor">{{ $kpis['eventos_realizados'] }}</div></td>
+        </tr>
+        <tr>
+            <td><div class="label">Horas presenciais</div><div class="valor">{{ number_format($kpis['horas_presenciais'], 1, ',', '.') }}</div></td>
+            <td><div class="label">Horas EaD</div><div class="valor">{{ number_format($kpis['horas_ead'], 1, ',', '.') }}</div></td>
+            <td><div class="label">Certificados emitidos</div><div class="valor">{{ $kpis['certificados_emitidos'] }}</div></td>
+            <td><div class="label">Avaliações respondidas</div><div class="valor">{{ $kpis['avaliacoes_respondidas'] }}</div></td>
+        </tr>
+        <tr>
+            <td><div class="label">Pendências de documentação</div><div class="valor">{{ $kpis['pendencias_documentacao'] }}</div></td>
+            <td></td><td></td><td></td>
+        </tr>
+    </table>
+
+    <h2>Metas por Ação Pedagógica</h2>
+    <table>
+        <thead><tr>
+            <th>Ação</th><th class="num">Previstas</th><th class="num">Inscritos</th>
+            <th class="num">Presentes</th><th class="num">Avaliações</th><th class="num">% Realizado</th>
+        </tr></thead>
+        <tbody>
+            @forelse($metas_por_acao as $r)
+                <tr>
+                    <td>{{ $r['acao'] }}</td>
+                    <td class="num">{{ $r['previstas'] }}</td>
+                    <td class="num">{{ $r['inscritos'] }}</td>
+                    <td class="num">{{ $r['presentes'] }}</td>
+                    <td class="num">{{ $r['avaliacoes'] }}</td>
+                    <td class="num">{{ number_format($r['pct_realizado'], 1, ',', '.') }}%</td>
+                </tr>
+            @empty
+                <tr><td colspan="6" class="vazio">Sem dados.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Participação por Região</h2>
+    <table>
+        <thead><tr><th>Região</th><th class="num">Previstas</th><th class="num">Presentes</th><th class="num">% Realizado</th></tr></thead>
+        <tbody>
+            @forelse($participacao_por_regiao as $r)
+                <tr><td>{{ $r['regiao'] }}</td><td class="num">{{ $r['previstas'] }}</td><td class="num">{{ $r['presentes'] }}</td><td class="num">{{ number_format($r['pct_realizado'], 1, ',', '.') }}%</td></tr>
+            @empty
+                <tr><td colspan="4" class="vazio">Sem dados.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Comparação entre Segmentos</h2>
+    <table>
+        <thead><tr><th>Segmento</th><th class="num">Presentes</th><th class="num">Participantes únicos</th></tr></thead>
+        <tbody>
+            @forelse($segmentos as $r)
+                <tr><td>{{ $r['segmento'] }}</td><td class="num">{{ $r['presentes'] }}</td><td class="num">{{ $r['participantes_unicos'] }}</td></tr>
+            @empty
+                <tr><td colspan="3" class="vazio">Sem dados.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Evolução Semestral</h2>
+    <table>
+        <thead><tr><th>Semestre</th><th class="num">Eventos</th><th class="num">Presentes</th><th class="num">Avaliações</th></tr></thead>
+        <tbody>
+            @forelse($evolucao_semestral as $r)
+                <tr><td>{{ $r['semestre'] }}</td><td class="num">{{ $r['eventos'] }}</td><td class="num">{{ $r['presentes'] }}</td><td class="num">{{ $r['avaliacoes'] }}</td></tr>
+            @empty
+                <tr><td colspan="4" class="vazio">Sem dados.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Municípios com Baixo Engajamento</h2>
+    <table>
+        <thead><tr><th>Município</th><th>Região</th><th class="num">Previstas</th><th class="num">Presentes</th><th class="num">% Realizado</th></tr></thead>
+        <tbody>
+            @forelse($municipios_baixo_engajamento as $r)
+                <tr><td>{{ $r['municipio'] }}</td><td>{{ $r['regiao'] }}</td><td class="num">{{ $r['previstas'] }}</td><td class="num">{{ $r['presentes'] }}</td><td class="num">{{ number_format($r['pct_realizado'], 1, ',', '.') }}%</td></tr>
+            @empty
+                <tr><td colspan="5" class="vazio">Nenhum.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Eventos sem Avaliação Registrada</h2>
+    <table>
+        <thead><tr><th>Ação</th><th>Momento</th><th>Município</th><th>Data</th></tr></thead>
+        <tbody>
+            @forelse($eventos_sem_avaliacao as $r)
+                <tr><td>{{ $r['acao'] }}</td><td>{{ $r['momento'] }}</td><td>{{ $r['municipio'] }}</td><td>{{ \Illuminate\Support\Carbon::parse($r['dia'])->format('d/m/Y') }}</td></tr>
+            @empty
+                <tr><td colspan="4" class="vazio">Nenhum.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Participantes com Recorrência de Ausência</h2>
+    <table>
+        <thead><tr><th>Participante</th><th>Município</th><th class="num">Ausências</th></tr></thead>
+        <tbody>
+            @forelse($recorrencia_ausencia as $r)
+                <tr><td>{{ $r['participante'] }}</td><td>{{ $r['municipio'] }}</td><td class="num">{{ $r['ausencias'] }}</td></tr>
+            @empty
+                <tr><td colspan="3" class="vazio">Nenhum.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\IndicadorController;
 use App\Http\Controllers\InscricaoController;
 use App\Http\Controllers\ModeloCertificadoController;
 use App\Http\Controllers\MunicipioController;
+use App\Http\Controllers\PainelGerencialController;
 use App\Http\Controllers\ParticipantesExclusivosController;
 use App\Http\Controllers\PresencaController;
 use App\Http\Controllers\PresencaImportController;
@@ -275,6 +276,15 @@ Route::middleware(['auth', 'role:administrador|gerente|eq_pedagogica|articulador
         ->name('relatorio-quantitativo.exportar-momento');
     Route::get('/relatorio-quantitativo/exportar-total-geral', [RelatorioQuantitativoController::class, 'exportarTotalGeral'])
         ->name('relatorio-quantitativo.exportar-total-geral');
+
+    Route::get('/painel-gerencial', [PainelGerencialController::class, 'index'])
+        ->name('painel-gerencial.index');
+    Route::get('/painel-gerencial/dados', [PainelGerencialController::class, 'dados'])
+        ->name('painel-gerencial.dados');
+    Route::get('/painel-gerencial/momentos', [PainelGerencialController::class, 'momentos'])
+        ->name('painel-gerencial.momentos');
+    Route::get('/painel-gerencial/exportar', [PainelGerencialController::class, 'exportar'])
+        ->name('painel-gerencial.exportar');
 });
 
 Route::middleware(['auth', 'role:administrador|gerente|eq_pedagogica|articulador'])->group(function () {

--- a/tests/Feature/PainelGerencialControllerTest.php
+++ b/tests/Feature/PainelGerencialControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\RolesPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\PdfBuilder;
+use Tests\TestCase;
+
+class PainelGerencialControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesPermissionsSeeder::class);
+    }
+
+    private function comPapel(string $papel): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($papel);
+
+        return $user;
+    }
+
+    public function test_index_acessivel_para_gerente(): void
+    {
+        $this->actingAs($this->comPapel('gerente'))
+            ->get(route('painel-gerencial.index'))
+            ->assertOk()
+            ->assertViewIs('painel-gerencial.index');
+    }
+
+    public function test_index_negado_para_participante(): void
+    {
+        $this->actingAs($this->comPapel('participante'))
+            ->get(route('painel-gerencial.index'))
+            ->assertForbidden();
+    }
+
+    public function test_dados_retorna_json_com_blocos(): void
+    {
+        $this->actingAs($this->comPapel('administrador'))
+            ->getJson(route('painel-gerencial.dados'))
+            ->assertOk()
+            ->assertJsonStructure([
+                'kpis' => ['municipios_ativos', 'participantes_unicos', 'certificados_emitidos'],
+                'metas_por_acao',
+                'participacao_por_regiao',
+                'segmentos',
+                'evolucao_semestral',
+                'municipios_baixo_engajamento',
+                'eventos_sem_avaliacao',
+                'recorrencia_ausencia',
+            ]);
+    }
+
+    public function test_exportar_xlsx(): void
+    {
+        $response = $this->actingAs($this->comPapel('administrador'))
+            ->get(route('painel-gerencial.exportar', ['formato' => 'xlsx']));
+
+        $response->assertOk();
+        $this->assertStringContainsString('.xlsx', $response->headers->get('content-disposition'));
+        $this->assertStringContainsString(
+            'spreadsheetml',
+            $response->headers->get('content-type')
+        );
+    }
+
+    public function test_exportar_pdf_usa_view_e_branding(): void
+    {
+        $builder = Mockery::mock(PdfBuilder::class);
+        $builder->shouldReceive('format')->andReturnSelf();
+        $builder->shouldReceive('landscape')->andReturnSelf();
+        $builder->shouldReceive('withAlfaEjaBrand')->andReturnSelf();
+        $builder->shouldReceive('download')->andReturnSelf();
+        $builder->shouldReceive('toResponse')->andReturn(response('ok'));
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->withArgs(fn ($view, $data) => $view === 'painel-gerencial.pdf' && isset($data['kpis']))
+            ->andReturn($builder);
+
+        $this->actingAs($this->comPapel('administrador'))
+            ->get(route('painel-gerencial.exportar', ['formato' => 'pdf']))
+            ->assertOk();
+    }
+}

--- a/tests/Feature/PainelGerencialServiceTest.php
+++ b/tests/Feature/PainelGerencialServiceTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Atividade;
+use App\Models\Evento;
+use App\Models\User;
+use App\Services\PainelGerencialService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class PainelGerencialServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PainelGerencialService $service;
+
+    private int $municipioId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(PainelGerencialService::class);
+        $this->seedCenario();
+    }
+
+    /**
+     * Cenário controlado:
+     * - 1 região / estado / município
+     * - 1 evento Presencial com 2 atividades em 2026-S1 (carga 120min cada = 2h cada)
+     * - p1: presente, avaliou, certificado, documentação completa
+     * - p2: presente, sem CPF (pendência), tag "Rede de Ensino"
+     * - p3: inscrito nas 2 atividades, ausente em ambas (recorrência = 2)
+     */
+    private function seedCenario(): void
+    {
+        $regiaoId = DB::table('regiaos')->insertGetId(['nome' => 'Nordeste', 'created_at' => now(), 'updated_at' => now()]);
+        $estadoId = DB::table('estados')->insertGetId(['regiao_id' => $regiaoId, 'nome' => 'Pernambuco', 'sigla' => 'PE', 'created_at' => now(), 'updated_at' => now()]);
+        $this->municipioId = DB::table('municipios')->insertGetId(['estado_id' => $estadoId, 'nome' => 'Recife', 'created_at' => now(), 'updated_at' => now()]);
+
+        $evento = Evento::factory()->create(['modalidade' => 'Presencial', 'nome' => 'Formação Inicial']);
+
+        $a1 = Atividade::factory()->create([
+            'evento_id' => $evento->id, 'municipio_id' => $this->municipioId,
+            'dia' => '2026-02-10', 'hora_inicio' => '09:00:00', 'hora_fim' => '11:00:00',
+            'publico_esperado' => 10, 'carga_horaria' => 120,
+        ]);
+        $a2 = Atividade::factory()->create([
+            'evento_id' => $evento->id, 'municipio_id' => $this->municipioId,
+            'dia' => '2026-03-10', 'hora_inicio' => '09:00:00', 'hora_fim' => '11:00:00',
+            'publico_esperado' => 10, 'carga_horaria' => 120,
+        ]);
+
+        $p1 = $this->participante(['cpf' => '11111111111', 'telefone' => '81999990000', 'tag' => null]);
+        $p2 = $this->participante(['cpf' => null, 'telefone' => '81999991111', 'tag' => 'Rede de Ensino']);
+        $p3 = $this->participante(['cpf' => '33333333333', 'telefone' => '81999992222', 'tag' => 'Movimento Social']);
+
+        // Presentes em a1
+        $this->presenca($evento->id, $a1->id, $p1, 'presente', avaliou: true, certificado: true);
+        $this->presenca($evento->id, $a1->id, $p2, 'presente');
+
+        // p3 inscrito nas 2 atividades, sem presença (ausente) -> 2 ausências
+        $this->inscricao($evento->id, $a1->id, $p3);
+        $this->inscricao($evento->id, $a2->id, $p3);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attrs
+     */
+    private function participante(array $attrs): int
+    {
+        $userId = User::factory()->create()->id;
+
+        return DB::table('participantes')->insertGetId(array_merge([
+            'user_id' => $userId,
+            'municipio_id' => $this->municipioId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], $attrs));
+    }
+
+    private function inscricao(int $eventoId, int $atividadeId, int $participanteId): int
+    {
+        return DB::table('inscricaos')->insertGetId([
+            'evento_id' => $eventoId,
+            'atividade_id' => $atividadeId,
+            'participante_id' => $participanteId,
+            'ouvinte' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function presenca(int $eventoId, int $atividadeId, int $participanteId, string $status, bool $avaliou = false, bool $certificado = false): void
+    {
+        $inscricaoId = $this->inscricao($eventoId, $atividadeId, $participanteId);
+
+        DB::table('presencas')->insert([
+            'inscricao_id' => $inscricaoId,
+            'atividade_id' => $atividadeId,
+            'status' => $status,
+            'avaliacao_respondida' => $avaliou,
+            'certificado_emitido' => $certificado,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function payload(array $query = []): array
+    {
+        return $this->service->buildPayload(new Request($query));
+    }
+
+    public function test_kpis_refletem_o_cenario(): void
+    {
+        $kpis = $this->payload()['kpis'];
+
+        $this->assertSame(1, $kpis['municipios_ativos']);
+        $this->assertSame(1, $kpis['eventos_realizados']);
+        $this->assertSame(2, $kpis['participantes_totais']);
+        $this->assertSame(2, $kpis['participantes_unicos']);
+        $this->assertSame(4.0, $kpis['horas_presenciais']); // 2 atividades x 2h
+        $this->assertSame(0.0, $kpis['horas_ead']);
+        $this->assertSame(1, $kpis['certificados_emitidos']);
+        $this->assertSame(1, $kpis['avaliacoes_respondidas']);
+        $this->assertSame(1, $kpis['pendencias_documentacao']); // p2 sem CPF
+    }
+
+    public function test_metas_por_acao(): void
+    {
+        $metas = $this->payload()['metas_por_acao'];
+
+        $this->assertCount(1, $metas);
+        $this->assertSame('Formação Inicial', $metas[0]['acao']);
+        $this->assertSame(20, $metas[0]['previstas']); // 10 + 10
+        $this->assertSame(2, $metas[0]['presentes']);
+        $this->assertSame(1, $metas[0]['avaliacoes']);
+        $this->assertSame(3, $metas[0]['inscritos']); // p1, p2, p3
+        $this->assertSame(10.0, $metas[0]['pct_realizado']); // 2/20
+    }
+
+    public function test_participacao_por_regiao(): void
+    {
+        $regioes = $this->payload()['participacao_por_regiao'];
+
+        $nordeste = collect($regioes)->firstWhere('regiao', 'Nordeste');
+        $this->assertNotNull($nordeste);
+        $this->assertSame(20, $nordeste['previstas']);
+        $this->assertSame(2, $nordeste['presentes']);
+    }
+
+    public function test_segmentos(): void
+    {
+        $segmentos = collect($this->payload()['segmentos']);
+
+        $this->assertSame(1, $segmentos->firstWhere('segmento', 'Rede de Ensino')['presentes']);
+        // p3 (Movimento Social) está ausente, então não aparece entre presentes.
+        $this->assertNull($segmentos->firstWhere('segmento', 'Movimento Social'));
+    }
+
+    public function test_evolucao_semestral(): void
+    {
+        $evolucao = $this->payload()['evolucao_semestral'];
+
+        $this->assertCount(1, $evolucao);
+        $this->assertSame('2026-S1', $evolucao[0]['semestre']);
+        $this->assertSame(2, $evolucao[0]['presentes']);
+        $this->assertSame(1, $evolucao[0]['avaliacoes']);
+    }
+
+    public function test_municipios_baixo_engajamento(): void
+    {
+        // presentes 2 / previstas 20 = 10% < 50% (limite padrão)
+        $baixo = $this->payload()['municipios_baixo_engajamento'];
+
+        $this->assertCount(1, $baixo);
+        $this->assertSame('Recife', $baixo[0]['municipio']);
+        $this->assertSame(10.0, $baixo[0]['pct_realizado']);
+    }
+
+    public function test_recorrencia_ausencia(): void
+    {
+        $ausencias = $this->payload()['recorrencia_ausencia'];
+
+        $this->assertCount(1, $ausencias); // apenas p3, com 2 ausências
+        $this->assertSame(2, $ausencias[0]['ausencias']);
+    }
+
+    public function test_eventos_sem_avaliacao(): void
+    {
+        // a1 teve avaliação respondida; a2 (passada) não teve nenhuma presença/avaliação.
+        $sem = $this->payload()['eventos_sem_avaliacao'];
+
+        $this->assertCount(1, $sem);
+        $this->assertSame('Formação Inicial', $sem[0]['acao']);
+    }
+
+    public function test_filtro_por_regiao_inexistente_zera_resultados(): void
+    {
+        $kpis = $this->payload(['regiao_id' => 999999])['kpis'];
+
+        $this->assertSame(0, $kpis['participantes_totais']);
+        $this->assertSame(0, $kpis['municipios_ativos']);
+    }
+}


### PR DESCRIPTION
Nova tela /painel-gerencial com KPIs, gráficos (Chart.js) e tabelas consolidando os quantitativos por Ação Pedagógica com recorte de região e município: público esperado x inscritos x presentes x avaliações, municípios ativos, participantes únicos, horas presenciais/EaD, certificados, pendências de documentação, participação por região, segmentos, evolução semestral (derivada das datas), municípios com baixo engajamento, eventos sem avaliação e recorrência de ausência.

- Agregação centralizada em PainelGerencialService (reutilizada por tela, PDF e XLSX).
- Export PDF (margem superior calculada pela proporção da imagem do header) e XLSX com uma aba por bloco.
- Tabelas com scroll interno e cabeçalho fixo.
- Testes de service e controller.