### PR TITLE
feat(atividades): reformula tabela de momentos com filtro por município

### DIFF
--- a/app/Http/Controllers/AtividadeController.php
+++ b/app/Http/Controllers/AtividadeController.php
@@ -22,20 +22,30 @@ class AtividadeController extends Controller
 {
     use AuthorizesRequests;
 
-    public function index(Evento $evento)
+    public function index(Request $request, Evento $evento)
     {
         $userId = auth()->id();
+
+        $municipiosDisponiveis = Municipio::whereHas('atividades', fn ($q) => $q->where('evento_id', $evento->id))
+            ->with('estado')
+            ->orderBy('nome')
+            ->get();
 
         $atividades = $evento->atividades()
             ->with([
                 'municipios.estado',
                 'avaliacaoAtividades' => fn ($rel) => $rel->when($userId, fn ($query) => $query->where('user_id', $userId)),
             ])
+            ->when($request->filled('municipio_id'), fn ($q) => $q->whereHas(
+                'municipios',
+                fn ($q2) => $q2->where('municipios.id', $request->municipio_id)
+            ))
             ->orderByDesc('dia')
             ->orderByDesc('hora_inicio')
-            ->paginate(12);
+            ->paginate(12)
+            ->appends($request->query());
 
-        return view('atividades.index', compact('evento', 'atividades'));
+        return view('atividades.index', compact('evento', 'atividades', 'municipiosDisponiveis'));
     }
 
     public function create(Evento $evento)

--- a/app/Models/Municipio.php
+++ b/app/Models/Municipio.php
@@ -8,11 +8,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Municipio extends Model
 {
     use SoftDeletes;
+
     protected $table = 'municipios';
+
     protected $fillable = [
         'estado_id',
         'nome',
     ];
+
     public function estado()
     {
         return $this->belongsTo(Estado::class);
@@ -22,10 +25,17 @@ class Municipio extends Model
     {
         return $this->hasMany(Agendamento::class);
     }
-    
+
+    public function atividades()
+    {
+        return $this->belongsToMany(Atividade::class, 'atividade_municipio')
+            ->withTimestamps();
+    }
+
     public function getNomeComEstadoAttribute(): string
     {
         $sigla = $this->estado?->sigla; // << usa 'sigla'
-        return trim($this->nome . ($sigla ? ' - ' . $sigla : ''));
+
+        return trim($this->nome.($sigla ? ' - '.$sigla : ''));
     }
 }

--- a/resources/views/atividades/index.blade.php
+++ b/resources/views/atividades/index.blade.php
@@ -1,5 +1,13 @@
 @extends('layouts.app')
 
+@push('styles')
+<style>
+  .atividades-actions-dropdown .dropdown-menu {
+    position: fixed !important;
+  }
+</style>
+@endpush
+
 @section('content')
   <div class="container">
     <div class="d-flex justify-content-between align-items-center mb-4">
@@ -16,15 +24,32 @@
       @endhasanyrole
     </div>
 
+    <form method="GET" action="{{ route('eventos.atividades.index', $evento) }}" class="row g-2 align-items-end mb-3">
+      <div class="col-auto">
+        <label for="municipio_id" class="form-label mb-0 small text-muted">Município</label>
+        <select name="municipio_id" id="municipio_id" class="form-select form-select-sm" onchange="this.form.submit()">
+          <option value="">Todos</option>
+          @foreach($municipiosDisponiveis as $m)
+            <option value="{{ $m->id }}" @selected(request('municipio_id') == $m->id)>
+              {{ $m->nome_com_estado ?? $m->nome }}
+            </option>
+          @endforeach
+        </select>
+      </div>
+      @if(request('municipio_id'))
+        <div class="col-auto">
+          <a href="{{ route('eventos.atividades.index', $evento) }}" class="btn btn-sm btn-outline-secondary">Limpar filtro</a>
+        </div>
+      @endif
+    </form>
+
     <div class="table-responsive">
       <table class="table table-hover align-middle">
         <thead class="table-light">
           <tr>
             <th>Dia</th>
-            <th>Hora início</th>
-            <th>Hora de término</th>
             <th>Municípios</th>
-            <th>Público esperado</th>
+            <th>Descrição</th>
             <th>Carga horária</th>
             <th>Status</th>
             @auth
@@ -42,10 +67,8 @@
             @endphp
             <tr>
               <td>{{ \Carbon\Carbon::parse($at->dia)->format('d/m/Y') }}</td>
-              <td>{{ \Carbon\Carbon::parse($at->hora_inicio)->format('H:i') }}</td>
-              <td>{{ $at->hora_fim ? \Carbon\Carbon::parse($at->hora_fim)->format('H:i') : '—' }}</td>
               <td>{{ $munLabel }}</td>
-              <td>{{ $at->publico_esperado ? number_format($at->publico_esperado, 0, ',', '.') : '—' }}</td>
+              <td>{{ $at->descricao }}</td>
               <td>
                 {{ !is_null($at->carga_horaria) ? \App\Support\CargaHoraria::formatMinutos((int) $at->carga_horaria) : '—' }}
               </td>
@@ -66,33 +89,44 @@
               <td class="text-end text-nowrap">
                 @php $minhaAvaliacaoAtividade = $at->minha_avaliacao_atividade; @endphp
 
-                <a href="{{ route('atividades.show', $at) }}" class="btn btn-sm btn-outline-primary">Ver</a>
+                <div class="dropdown atividades-actions-dropdown">
+                  <button class="btn btn-sm btn-engaja dropdown-toggle" type="button"
+                          data-bs-toggle="dropdown" aria-expanded="false">
+                    Gerenciar
+                  </button>
+                  <ul class="dropdown-menu dropdown-menu-end">
+                    <li><a class="dropdown-item" href="{{ route('atividades.show', $at) }}">Ver</a></li>
 
-                @hasanyrole('administrador|gerente|eq_pedagogica')
-                <a href="{{ route('atividades.edit', $at) }}" class="btn btn-sm btn-outline-secondary">Editar</a>
-                @endhasanyrole
+                    @hasanyrole('administrador|gerente|eq_pedagogica')
+                    <li><a class="dropdown-item" href="{{ route('atividades.edit', $at) }}">Editar</a></li>
+                    @endhasanyrole
 
-                 <a href="{{ $minhaAvaliacaoAtividade
-                        ? route('avaliacao-atividade.edit',   $at)
-                        : route('avaliacao-atividade.create', $at) }}"
-                   class="btn btn-sm {{ $minhaAvaliacaoAtividade ? 'btn-warning' : 'btn-outline-warning' }}"
-                   title="{{ $minhaAvaliacaoAtividade ? 'Editar meu relatório' : 'Criar meu relatório' }}">
-                   📋 {{ $minhaAvaliacaoAtividade ? 'Meu relatório' : 'Criar relatório' }}
-                </a>
+                    <li>
+                      <a class="dropdown-item" href="{{ $minhaAvaliacaoAtividade
+                          ? route('avaliacao-atividade.edit',   $at)
+                          : route('avaliacao-atividade.create', $at) }}">
+                        📋 {{ $minhaAvaliacaoAtividade ? 'Editar meu relatório' : 'Criar meu relatório' }}
+                      </a>
+                    </li>
 
-                @hasrole('administrador')
-                <form class="d-inline" method="POST" action="{{ route('atividades.destroy', $at) }}"
-                  data-confirm="Tem certeza que deseja excluir este momento?">
-                  @csrf @method('DELETE')
-                  <button class="btn btn-sm btn-outline-danger">Excluir</button>
-                </form>
-                @endhasrole
+                    @hasrole('administrador')
+                    <li><hr class="dropdown-divider"></li>
+                    <li>
+                      <form method="POST" action="{{ route('atividades.destroy', $at) }}"
+                        data-confirm="Tem certeza que deseja excluir este momento?">
+                        @csrf @method('DELETE')
+                        <button type="submit" class="dropdown-item text-danger">Excluir</button>
+                      </form>
+                    </li>
+                    @endhasrole
+                  </ul>
+                </div>
               </td>
               @endauth
             </tr>
           @empty
             <tr>
-              <td colspan="{{ $temPermissao ? 8 : 7 }}" class="text-center text-muted py-4">Nenhum momento cadastrado.</td>
+              <td colspan="{{ $temPermissao ? 6 : 5 }}" class="text-center text-muted py-4">Nenhum momento cadastrado.</td>
             </tr>
           @endforelse
         </tbody>


### PR DESCRIPTION
Ajustes na tela de listagem de momentos (/eventos/{evento}/atividades):
- Remove colunas "Hora início", "Hora de término" e "Público esperado"
- Adiciona coluna "Descrição do momento"
- Unifica botões de ação (Ver, Editar, Relatório, Excluir) em dropdown "Gerenciar"
- Implementa filtro por município na listagem, com persistência via querystring
- Adiciona relacionamento belongsToMany inverso em Municipio::atividades()
- Corrige dropdown para não criar scroll (position: fixed)