### PR TITLE
style(cartas): ajusta dimensões das seções roxa e azul para 664px

### DIFF
--- a/resources/views/cartas/apresentacao.blade.php
+++ b/resources/views/cartas/apresentacao.blade.php
@@ -269,8 +269,9 @@
         background: var(--land-purple);
         color: var(--land-paper);
         text-align: center;
+        box-sizing: border-box;
+        height: 664px;
         padding: 64px 0;
-        min-height: 80vh;
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -469,8 +470,9 @@
         background: var(--land-blue);
         color: var(--land-paper);
         text-align: center;
-        padding: 80px 0;
-        min-height: 80vh;
+        box-sizing: border-box;
+        height: 664px;
+        padding: 264px 0;
         display: flex;
         flex-direction: column;
         justify-content: center;


### PR DESCRIPTION
Redimensiona .land-about (fundo roxo) e .land-closing (fundo azul) com altura fixa de 664px e padding vertical conforme o design no Figma.