### PR TITLE
feat: Implementar curadoria de dados demográficos

### DIFF
--- a/app/Http/Controllers/AtividadeController.php
+++ b/app/Http/Controllers/AtividadeController.php
@@ -318,6 +318,10 @@ class AtividadeController extends Controller
 
         $user = auth()->user();
 
+        if (! $user->demograficosCompletos()) {
+            return back()->with('erro_demograficos', 'Para confirmar sua presença, é necessário preencher seus dados demográficos no Engaja. Por favor, preencha o formulário acima e tente novamente.');
+        }
+
         // 1) Garante Participante para o usuário
         $participante = Participante::firstOrCreate(['user_id' => $user->id], []);
 

--- a/app/Http/Controllers/CuradoriaDemograficoController.php
+++ b/app/Http/Controllers/CuradoriaDemograficoController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class CuradoriaDemograficoController extends Controller
+{
+    public function index()
+    {
+        // Require role 'administrador' or 'gerente'
+        if (! auth()->user()->hasAnyRole(['administrador', 'gerente'])) {
+            abort(403, 'Acesso negado.');
+        }
+
+        $curadorias = \App\Models\CuradoriaDemografico::with('user')
+            ->where('vinculado', false)
+            ->orderBy('created_at', 'desc')
+            ->paginate(15);
+
+        return view('curadoria_demograficos.index', compact('curadorias'));
+    }
+
+    public function vincular(Request $request, \App\Models\CuradoriaDemografico $curadoria)
+    {
+        if (! auth()->user()->hasAnyRole(['administrador', 'gerente'])) {
+            abort(403, 'Acesso negado.');
+        }
+
+        $usuario = $curadoria->user;
+        if ($usuario) {
+            $usuario->update([
+                'identidade_genero' => $curadoria->identidade_genero,
+                'identidade_genero_outro' => $curadoria->identidade_genero_outro,
+                'raca_cor' => $curadoria->raca_cor,
+                'comunidade_tradicional' => $curadoria->comunidade_tradicional,
+                'comunidade_tradicional_outro' => $curadoria->comunidade_tradicional_outro,
+                'faixa_etaria' => $curadoria->faixa_etaria,
+                'pcd' => $curadoria->pcd,
+                'orientacao_sexual' => $curadoria->orientacao_sexual,
+                'orientacao_sexual_outra' => $curadoria->orientacao_sexual_outra,
+            ]);
+
+            $curadoria->update(['vinculado' => true]);
+
+            return redirect()->route('curadoria.index')->with('success', 'Dados demográficos vinculados ao usuário com sucesso!');
+        }
+
+        return redirect()->route('curadoria.index')->with('error', 'Usuário não encontrado.');
+    }
+
+    public function destroy(\App\Models\CuradoriaDemografico $curadoria)
+    {
+        if (! auth()->user()->hasAnyRole(['administrador', 'gerente'])) {
+            abort(403, 'Acesso negado.');
+        }
+
+        $curadoria->delete();
+
+        return redirect()->route('curadoria.index')->with('success', 'Registro excluído com sucesso!');
+    }
+}

--- a/app/Http/Controllers/PresencaController.php
+++ b/app/Http/Controllers/PresencaController.php
@@ -5,8 +5,12 @@ namespace App\Http\Controllers;
 use App\Models\Atividade;
 use App\Models\Inscricao;
 use App\Models\Participante;
+use App\Models\Presenca;
 use App\Models\User;
+use App\Models\CuradoriaDemografico;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Throwable;
 
 class PresencaController extends Controller
 {
@@ -29,8 +33,7 @@ class PresencaController extends Controller
             ->orWhere('telefone', $campo)
             ->first();
 
-        if(!$usuario && $participante)
-        {
+        if (!$usuario && $participante) {
             $usuario = User::find($participante->user_id);
         }
 
@@ -42,9 +45,95 @@ class PresencaController extends Controller
                 ->with('error', 'Seus dados não foram encontrados no sistema. Solicitamos, por gentileza, que registre sua presença no formulário impresso.')
                 ->with('show_register_button', true);
         }
+
         if ($usuario && !$participante) {
             $participante = Participante::where('user_id', $usuario->id)->first();
         }
+
+        // Se dados demográficos incompletos, abre o modal de preenchimento
+        // para qualquer pessoa (mesmo deslogada) completar os dados do participante
+        if ($usuario && ! $usuario->demograficosCompletos()) {
+            return redirect()
+                ->back()
+                ->withInput()
+                ->with('demograficos_pendentes', true)
+                ->with('demograficos_user_token', encrypt($usuario->id))
+                ->with('demograficos_user_nome', $usuario->name)
+                ->with('demograficos_campo_input', $request->campo);
+        }
+
+        return $this->confirmarPresencaParaUsuario($atividade, $usuario, $participante);
+    }
+
+    /**
+     * Salva os dados demográficos do usuário identificado pelo token criptografado
+     * e em seguida confirma a presença na atividade.
+     */
+    public function salvarDemograficosEConfirmar(Request $request, Atividade $atividade)
+    {
+        $request->validate([
+            'user_token'                   => 'required|string',
+            'identidade_genero'            => 'required|string',
+            'identidade_genero_outro'      => 'nullable|string|max:255|required_if:identidade_genero,Outro',
+            'raca_cor'                     => 'required|string',
+            'comunidade_tradicional'       => 'required|string',
+            'comunidade_tradicional_outro' => 'nullable|string|max:255|required_if:comunidade_tradicional,Outro',
+            'faixa_etaria'                 => 'required|string',
+            'pcd'                          => 'required|string',
+            'orientacao_sexual'            => 'required|string',
+            'orientacao_sexual_outra'      => 'nullable|string|max:255|required_if:orientacao_sexual,Outra',
+        ], [
+            'identidade_genero.required'       => 'Identidade de gênero é obrigatória.',
+            'raca_cor.required'                => 'Raça/Cor é obrigatória.',
+            'comunidade_tradicional.required'  => 'Pertencimento a comunidade é obrigatório.',
+            'faixa_etaria.required'            => 'Faixa etária é obrigatória.',
+            'pcd.required'                     => 'Campo PcD é obrigatório.',
+            'orientacao_sexual.required'       => 'Orientação sexual é obrigatória.',
+        ]);
+
+        // Resolve o usuário de forma segura via token criptografado
+        try {
+            $userId = decrypt($request->user_token);
+        } catch (Throwable) {
+            return redirect()
+                ->route('presenca.confirmar', $atividade)
+                ->with('error', 'Token inválido. Por favor, reinicie o processo de confirmação de presença.');
+        }
+
+        $usuario = User::find($userId);
+        if (! $usuario) {
+            return redirect()
+                ->route('presenca.confirmar', $atividade)
+                ->with('error', 'Usuário não encontrado. Por favor, reinicie o processo.');
+        }
+
+        // Salva os dados demográficos na tabela de curadoria
+        CuradoriaDemografico::create([
+            'user_id'                      => $usuario->id,
+            'identidade_genero'            => $request->identidade_genero,
+            'identidade_genero_outro'      => $request->identidade_genero_outro,
+            'raca_cor'                     => $request->raca_cor,
+            'comunidade_tradicional'       => $request->comunidade_tradicional,
+            'comunidade_tradicional_outro' => $request->comunidade_tradicional_outro,
+            'faixa_etaria'                 => $request->faixa_etaria,
+            'pcd'                          => $request->pcd,
+            'orientacao_sexual'            => $request->orientacao_sexual,
+            'orientacao_sexual_outra'      => $request->orientacao_sexual_outra,
+        ]);
+
+        $participante = Participante::where('user_id', $usuario->id)->first();
+        if (! $participante) {
+            $participante = Participante::firstOrCreate(['user_id' => $usuario->id]);
+        }
+
+        return $this->confirmarPresencaParaUsuario($atividade, $usuario, $participante);
+    }
+
+    /**
+     * Lógica compartilhada de confirmação de presença para um usuário/participante já resolvido.
+     */
+    private function confirmarPresencaParaUsuario(Atividade $atividade, User $usuario, ?Participante $participante)
+    {
         $evento = $atividade->evento;
 
         $inscricao = Inscricao::withTrashed()
@@ -86,24 +175,23 @@ class PresencaController extends Controller
             $presenca->avaliacao_respondida = false;
             $presenca->save();
         }
-        $dia = \Carbon\Carbon::parse($atividade->dia)
+
+        $dia = Carbon::parse($atividade->dia)
             ->locale('pt_BR')
-            ->translatedFormat('l, d \\d\\e F \\d\\e Y');
+            ->translatedFormat('l, d \d\e F \d\e Y');
 
         return redirect()
             ->route('presenca.confirmar', $atividade->id)
             ->with([
-                'usuario_nome' => $usuario->name,
-                'evento_nome' => $evento->nome,
-                'atividade_nome' => $atividade->descricao,
-                'dia' => $dia,
-                'success-presenca' => 'Presença confirmada com sucesso!',
-                // 'status_presenca_label' => $inscricao->ouvinte ? 'Ouvinte' : 'Presença',
-                // 'artigo_status_presenca' => $inscricao->ouvinte ? 'sua participação como ouvinte' : 'sua presença',
-                'status_presenca_label' => 'Sua presença foi confirmada!',
+                'usuario_nome'           => $usuario->name,
+                'evento_nome'            => $evento->nome,
+                'atividade_nome'         => $atividade->descricao,
+                'dia'                    => $dia,
+                'success-presenca'       => 'Presença confirmada com sucesso!',
+                'status_presenca_label'  => 'Sua presença foi confirmada!',
                 'artigo_status_presenca' => 'sua presença',
-                'avaliacao_token' => $presenca->avaliacao_respondida ? null : encrypt($presenca->id),
-                'avaliacao_disponivel' => ! $presenca->avaliacao_respondida,
+                'avaliacao_token'        => $presenca->avaliacao_respondida ? null : encrypt($presenca->id),
+                'avaliacao_disponivel'   => ! $presenca->avaliacao_respondida,
             ]);
     }
 }

--- a/app/Models/CuradoriaDemografico.php
+++ b/app/Models/CuradoriaDemografico.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CuradoriaDemografico extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'identidade_genero',
+        'identidade_genero_outro',
+        'raca_cor',
+        'comunidade_tradicional',
+        'comunidade_tradicional_outro',
+        'faixa_etaria',
+        'pcd',
+        'orientacao_sexual',
+        'orientacao_sexual_outra',
+        'vinculado',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -190,6 +190,24 @@ class User extends Authenticatable
             ->implode(' - ');
     }
 
+    /**
+     * Verifica se todos os campos demográficos obrigatórios estão preenchidos.
+     */
+    public function demograficosCompletos(): bool
+    {
+        $camposObrigatorios = [
+            'identidade_genero',
+            'raca_cor',
+            'comunidade_tradicional',
+            'faixa_etaria',
+            'pcd',
+            'orientacao_sexual',
+        ];
+
+        return ! collect($camposObrigatorios)
+            ->some(fn($campo) => empty($this->$campo));
+    }
+
     protected static function booted(): void
     {
         static::created(function (User $user) {

--- a/database/migrations/2026_08_10_191617_create_curadoria_demograficos_table.php
+++ b/database/migrations/2026_08_10_191617_create_curadoria_demograficos_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('curadoria_demograficos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('identidade_genero')->nullable();
+            $table->string('identidade_genero_outro')->nullable();
+            $table->string('raca_cor')->nullable();
+            $table->string('comunidade_tradicional')->nullable();
+            $table->string('comunidade_tradicional_outro')->nullable();
+            $table->string('faixa_etaria')->nullable();
+            $table->string('pcd')->nullable();
+            $table->string('orientacao_sexual')->nullable();
+            $table->string('orientacao_sexual_outra')->nullable();
+            $table->boolean('vinculado')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('curadoria_demograficos');
+    }
+};

--- a/resources/views/atividades/confirmar-presenca.blade.php
+++ b/resources/views/atividades/confirmar-presenca.blade.php
@@ -12,13 +12,27 @@
             <p class="mb-3">Para confirmar a sua presença nesta atividade e/ou responder a avaliação, preencha o campo com
               o seu e-mail, CPF ou
               telefone e clique no botão.<br /></p>
-            <form method="POST" action="{{ route('presenca.store', $atividade) }}">
+
+            {{-- Erro genérico / usuário não encontrado --}}
+            @if (session('error') && !session('demograficos_pendentes'))
+              <div class="alert alert-danger" role="alert">
+                {{ session('error') }}
+              </div>
+            @endif
+
+            {{-- Formulário principal de busca --}}
+            <form method="POST" action="{{ route('presenca.store', $atividade) }}" id="form-busca-presenca">
               @csrf
               <div class="mb-3">
-                <label for="email" class="form-label">E-mail, CPF ou telefone</label>
-                <input type="text" class="form-control" id="campo" name="campo" required>
+                <label for="campo" class="form-label">E-mail, CPF ou telefone</label>
+                <input type="text"
+                       class="form-control @error('campo') is-invalid @enderror"
+                       id="campo"
+                       name="campo"
+                       value="{{ old('campo', session('demograficos_campo_input')) }}"
+                       required>
                 @error('campo')
-                  <div class="text-danger mt-1">{{ $message }}</div>
+                  <div class="invalid-feedback">{{ $message }}</div>
                 @enderror
               </div>
               <div class="d-flex justify-content-end">
@@ -38,6 +52,236 @@
     </div>
   </div>
 
+  {{-- ================================================================
+       MODAL: Dados Demográficos Pendentes
+       Abre automaticamente quando o usuário é encontrado mas não tem
+       os dados demográficos preenchidos.
+  ================================================================ --}}
+  <div class="modal fade"
+       id="modalDemograficos"
+       tabindex="-1"
+       aria-labelledby="modalDemograficosLabel"
+       aria-modal="true"
+       role="dialog"
+       data-bs-backdrop="static"
+       data-bs-keyboard="false">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content">
+
+        <div class="modal-header bg-engaja text-white">
+          <h5 class="modal-title fw-bold" id="modalDemograficosLabel">
+            📋 Dados demográficos pendentes
+          </h5>
+        </div>
+
+        <div class="modal-body">
+          {{-- Banner identificando o usuário --}}
+          <div class="alert alert-info d-flex align-items-center gap-2 mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-person-fill flex-shrink-0" viewBox="0 0 16 16">
+              <path d="M3 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6"/>
+            </svg>
+            <div>
+              Preenchendo dados de: <strong>{{ session('demograficos_user_nome') }}</strong><br>
+              <small class="text-muted">Para confirmar a presença deste participante, preencha as informações abaixo.</small>
+            </div>
+          </div>
+
+          @if ($errors->any())
+            <div class="alert alert-danger">
+              <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                  <li>{{ $error }}</li>
+                @endforeach
+              </ul>
+            </div>
+          @endif
+
+          <form method="POST"
+                action="{{ route('presenca.demograficos', $atividade) }}"
+                id="form-demograficos-presenca">
+            @csrf
+
+            {{-- Token seguro do usuário (criptografado) --}}
+            <input type="hidden"
+                   name="user_token"
+                   value="{{ session('demograficos_user_token', old('user_token')) }}">
+
+            {{-- 1. Identidade de Gênero --}}
+            <div class="mb-3">
+              <label for="identidade_genero_qr" class="form-label fw-semibold">
+                Identidade de Gênero <span class="text-danger">*</span>
+              </label>
+              <select name="identidade_genero" id="identidade_genero_qr"
+                      class="form-select @error('identidade_genero') is-invalid @enderror"
+                      required onchange="toggleOutroQr(this, 'ig_outro_wrap_qr')">
+                <option value="" disabled selected>Selecione...</option>
+                <option value="Mulher Cisgênero"   {{ old('identidade_genero') == 'Mulher Cisgênero'   ? 'selected' : '' }}>Mulher Cisgênero</option>
+                <option value="Mulher Transsexual" {{ old('identidade_genero') == 'Mulher Transsexual' ? 'selected' : '' }}>Mulher Transsexual</option>
+                <option value="Homem Cisgênero"    {{ old('identidade_genero') == 'Homem Cisgênero'    ? 'selected' : '' }}>Homem Cisgênero</option>
+                <option value="Homem Transsexual"  {{ old('identidade_genero') == 'Homem Transsexual'  ? 'selected' : '' }}>Homem Transsexual</option>
+                <option value="Travesti"           {{ old('identidade_genero') == 'Travesti'           ? 'selected' : '' }}>Travesti</option>
+                <option value="Não binárie"        {{ old('identidade_genero') == 'Não binárie'        ? 'selected' : '' }}>Não binárie</option>
+                <option value="Prefiro não responder" {{ old('identidade_genero') == 'Prefiro não responder' ? 'selected' : '' }}>Prefiro não responder</option>
+                <option value="Outro"              {{ old('identidade_genero') == 'Outro'              ? 'selected' : '' }}>Outro</option>
+              </select>
+              @error('identidade_genero')
+                <div class="invalid-feedback">{{ $message }}</div>
+              @enderror
+              <div id="ig_outro_wrap_qr" class="mt-2" style="display:none">
+                <input type="text" name="identidade_genero_outro"
+                       class="form-control @error('identidade_genero_outro') is-invalid @enderror"
+                       placeholder="Especifique sua identidade de gênero"
+                       value="{{ old('identidade_genero_outro') }}">
+                @error('identidade_genero_outro')
+                  <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+              </div>
+            </div>
+
+            {{-- 2. Raça / Cor --}}
+            <div class="mb-3">
+              <label for="raca_cor_qr" class="form-label fw-semibold">
+                Raça / Cor <span class="text-danger">*</span>
+              </label>
+              <select name="raca_cor" id="raca_cor_qr"
+                      class="form-select @error('raca_cor') is-invalid @enderror"
+                      required>
+                <option value="" disabled selected>Selecione...</option>
+                <option value="Preta"                {{ old('raca_cor') == 'Preta'                ? 'selected' : '' }}>Preta</option>
+                <option value="Parda"                {{ old('raca_cor') == 'Parda'                ? 'selected' : '' }}>Parda</option>
+                <option value="Branca"               {{ old('raca_cor') == 'Branca'               ? 'selected' : '' }}>Branca</option>
+                <option value="Amarela"              {{ old('raca_cor') == 'Amarela'              ? 'selected' : '' }}>Amarela</option>
+                <option value="Indígena"             {{ old('raca_cor') == 'Indígena'             ? 'selected' : '' }}>Indígena</option>
+                <option value="Prefere não declarar" {{ old('raca_cor') == 'Prefere não declarar' ? 'selected' : '' }}>Prefere não declarar</option>
+              </select>
+              @error('raca_cor')
+                <div class="invalid-feedback">{{ $message }}</div>
+              @enderror
+            </div>
+
+            {{-- 3. Comunidade Tradicional --}}
+            <div class="mb-3">
+              <label for="comunidade_tradicional_qr" class="form-label fw-semibold">
+                Pertencimento a Povos ou Comunidades Tradicionais <span class="text-danger">*</span>
+              </label>
+              <select name="comunidade_tradicional" id="comunidade_tradicional_qr"
+                      class="form-select @error('comunidade_tradicional') is-invalid @enderror"
+                      required onchange="toggleOutroQr(this, 'ct_outro_wrap_qr')">
+                <option value="" disabled selected>Selecione...</option>
+                <option value="Não"                    {{ old('comunidade_tradicional') == 'Não'                    ? 'selected' : '' }}>Não</option>
+                <option value="Povos indígenas"        {{ old('comunidade_tradicional') == 'Povos indígenas'        ? 'selected' : '' }}>Povos indígenas</option>
+                <option value="Comunidades Quilombolas" {{ old('comunidade_tradicional') == 'Comunidades Quilombolas' ? 'selected' : '' }}>Comunidades Quilombolas</option>
+                <option value="Povos Ciganos"          {{ old('comunidade_tradicional') == 'Povos Ciganos'          ? 'selected' : '' }}>Povos Ciganos</option>
+                <option value="Ribeirinhos"            {{ old('comunidade_tradicional') == 'Ribeirinhos'            ? 'selected' : '' }}>Ribeirinhos</option>
+                <option value="Extrativistas"          {{ old('comunidade_tradicional') == 'Extrativistas'          ? 'selected' : '' }}>Extrativistas</option>
+                <option value="Outro"                  {{ old('comunidade_tradicional') == 'Outro'                  ? 'selected' : '' }}>Outro</option>
+              </select>
+              @error('comunidade_tradicional')
+                <div class="invalid-feedback">{{ $message }}</div>
+              @enderror
+              <div id="ct_outro_wrap_qr" class="mt-2" style="display:none">
+                <input type="text" name="comunidade_tradicional_outro"
+                       class="form-control @error('comunidade_tradicional_outro') is-invalid @enderror"
+                       placeholder="Especifique a comunidade tradicional"
+                       value="{{ old('comunidade_tradicional_outro') }}">
+                @error('comunidade_tradicional_outro')
+                  <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+              </div>
+            </div>
+
+            {{-- 4. Faixa Etária --}}
+            <div class="mb-3">
+              <label for="faixa_etaria_qr" class="form-label fw-semibold">
+                Faixa Etária <span class="text-danger">*</span>
+              </label>
+              <select name="faixa_etaria" id="faixa_etaria_qr"
+                      class="form-select @error('faixa_etaria') is-invalid @enderror"
+                      required>
+                <option value="" disabled selected>Selecione...</option>
+                <option value="Primeira infância (0 a 6 anos)"  {{ old('faixa_etaria') == 'Primeira infância (0 a 6 anos)'  ? 'selected' : '' }}>Primeira infância (0 a 6 anos)</option>
+                <option value="Criança (7 a 11 anos)"           {{ old('faixa_etaria') == 'Criança (7 a 11 anos)'           ? 'selected' : '' }}>Criança (7 a 11 anos)</option>
+                <option value="Adolescente (12 a 17 anos)"      {{ old('faixa_etaria') == 'Adolescente (12 a 17 anos)'      ? 'selected' : '' }}>Adolescente (12 a 17 anos)</option>
+                <option value="Adulto (18 a 59 anos)"           {{ old('faixa_etaria') == 'Adulto (18 a 59 anos)'           ? 'selected' : '' }}>Adulto (18 a 59 anos)</option>
+                <option value="Idoso (a partir dos 60 anos)"    {{ old('faixa_etaria') == 'Idoso (a partir dos 60 anos)'    ? 'selected' : '' }}>Idoso (a partir dos 60 anos)</option>
+              </select>
+              @error('faixa_etaria')
+                <div class="invalid-feedback">{{ $message }}</div>
+              @enderror
+            </div>
+
+            {{-- 5. PcD --}}
+            <div class="mb-3">
+              <label for="pcd_qr" class="form-label fw-semibold">
+                Pessoa com Deficiência (PcD) <span class="text-danger">*</span>
+              </label>
+              <select name="pcd" id="pcd_qr"
+                      class="form-select @error('pcd') is-invalid @enderror"
+                      required>
+                <option value="" disabled selected>Selecione...</option>
+                <option value="Não"         {{ old('pcd') == 'Não'         ? 'selected' : '' }}>Não</option>
+                <option value="Física"      {{ old('pcd') == 'Física'      ? 'selected' : '' }}>Física</option>
+                <option value="Auditiva"    {{ old('pcd') == 'Auditiva'    ? 'selected' : '' }}>Auditiva</option>
+                <option value="Visual"      {{ old('pcd') == 'Visual'      ? 'selected' : '' }}>Visual</option>
+                <option value="Intelectual" {{ old('pcd') == 'Intelectual' ? 'selected' : '' }}>Intelectual</option>
+                <option value="Múltipla"    {{ old('pcd') == 'Múltipla'    ? 'selected' : '' }}>Múltipla</option>
+              </select>
+              @error('pcd')
+                <div class="invalid-feedback">{{ $message }}</div>
+              @enderror
+            </div>
+
+            {{-- 6. Orientação Sexual --}}
+            <div class="mb-3">
+              <label for="orientacao_sexual_qr" class="form-label fw-semibold">
+                Orientação Sexual <span class="text-danger">*</span>
+              </label>
+              <select name="orientacao_sexual" id="orientacao_sexual_qr"
+                      class="form-select @error('orientacao_sexual') is-invalid @enderror"
+                      required onchange="toggleOutroQr(this, 'os_outra_wrap_qr')">
+                <option value="" disabled selected>Selecione...</option>
+                <option value="Lésbica"              {{ old('orientacao_sexual') == 'Lésbica'              ? 'selected' : '' }}>Lésbica</option>
+                <option value="Gay"                  {{ old('orientacao_sexual') == 'Gay'                  ? 'selected' : '' }}>Gay</option>
+                <option value="Bissexual"            {{ old('orientacao_sexual') == 'Bissexual'            ? 'selected' : '' }}>Bissexual</option>
+                <option value="Heterossexual"        {{ old('orientacao_sexual') == 'Heterossexual'        ? 'selected' : '' }}>Heterossexual</option>
+                <option value="Prefere não declarar" {{ old('orientacao_sexual') == 'Prefere não declarar' ? 'selected' : '' }}>Prefere não declarar</option>
+                <option value="Outra"                {{ old('orientacao_sexual') == 'Outra'                ? 'selected' : '' }}>Outra</option>
+              </select>
+              @error('orientacao_sexual')
+                <div class="invalid-feedback">{{ $message }}</div>
+              @enderror
+              <div id="os_outra_wrap_qr" class="mt-2" style="display:none">
+                <input type="text" name="orientacao_sexual_outra"
+                       class="form-control @error('orientacao_sexual_outra') is-invalid @enderror"
+                       placeholder="Especifique sua orientação sexual"
+                       value="{{ old('orientacao_sexual_outra') }}">
+                @error('orientacao_sexual_outra')
+                  <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+              </div>
+            </div>
+
+          </form>
+        </div>
+
+        <div class="modal-footer flex-column gap-2">
+          <button type="submit" form="form-demograficos-presenca" class="btn btn-engaja w-100 fw-bold">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2-circle me-1" viewBox="0 0 16 16">
+              <path d="M2.5 8a5.5 5.5 0 0 1 8.25-4.764.5.5 0 0 0 .5-.866A6.5 6.5 0 1 0 14.5 8a.5.5 0 0 0-1 0 5.5 5.5 0 1 1-11 0"/>
+              <path d="M15.354 3.354a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0z"/>
+            </svg>
+            Salvar dados e confirmar presença
+          </button>
+          <small class="text-muted text-center">
+            Esses dados são utilizados apenas para fins estatísticos e de políticas públicas.
+          </small>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  {{-- Modal de confirmação de presença bem-sucedida --}}
   <div class="modal fade" id="confirmacaoPresencaModal" tabindex="-1" aria-labelledby="confirmacaoPresencaModalLabel"
     aria-hidden="true">
     @php
@@ -82,6 +326,7 @@
     </div>
   </div>
 
+  {{-- Modal de cadastro no sistema --}}
   <div class="modal fade" id="cadastroSistemaModal" tabindex="-1" aria-labelledby="cadastroSistemaModalLabel"
     aria-hidden="true">
     <div class="modal-dialog modal modal-dialog-centered mt-1">
@@ -114,6 +359,7 @@
     </div>
   </div>
 
+  {{-- Scripts de controle dos modais --}}
   @if(session('success-presenca'))
     <script>
       document.addEventListener('DOMContentLoaded', function () {
@@ -137,4 +383,57 @@
       });
     </script>
   @endif
+
+  @if(session('demograficos_pendentes'))
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const modalEl = document.getElementById('modalDemograficos');
+        if (modalEl) {
+          const modal = new bootstrap.Modal(modalEl);
+          modal.show();
+          restoreOutroFieldsQr();
+        }
+      });
+    </script>
+  @endif
+
+  {{-- Também abre o modal se houve erro de validação no formulário demográfico --}}
+  @if($errors->any() && old('user_token'))
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const modalEl = document.getElementById('modalDemograficos');
+        if (modalEl) {
+          const modal = new bootstrap.Modal(modalEl);
+          modal.show();
+          restoreOutroFieldsQr();
+        }
+      });
+    </script>
+  @endif
+
+  <script>
+    function toggleOutroQr(select, wrapId) {
+      const wrap = document.getElementById(wrapId);
+      if (!wrap) return;
+      const mostrar = select.value === 'Outro' || select.value === 'Outra';
+      wrap.style.display = mostrar ? 'block' : 'none';
+      const input = wrap.querySelector('input');
+      if (input) input.required = mostrar;
+    }
+
+    function restoreOutroFieldsQr() {
+      [
+        { selectId: 'identidade_genero_qr',      wrapId: 'ig_outro_wrap_qr' },
+        { selectId: 'comunidade_tradicional_qr',  wrapId: 'ct_outro_wrap_qr' },
+        { selectId: 'orientacao_sexual_qr',       wrapId: 'os_outra_wrap_qr' },
+      ].forEach(({ selectId, wrapId }) => {
+        const select = document.getElementById(selectId);
+        if (select && (select.value === 'Outro' || select.value === 'Outra')) {
+          const wrap = document.getElementById(wrapId);
+          if (wrap) wrap.style.display = 'block';
+        }
+      });
+    }
+  </script>
+
 @endsection

--- a/resources/views/atividades/show.blade.php
+++ b/resources/views/atividades/show.blade.php
@@ -52,7 +52,22 @@
         <div class="d-flex justify-content-between align-items-start mb-4">
             <x-header-atividade :atividade="$atividade" />
 
-            <div class="d-flex flex-wrap gap-2 mb-3">
+        <div class="d-flex flex-wrap gap-2 mb-3">
+                {{-- Alerta de dados demográficos pendentes --}}
+                @if (session('erro_demograficos'))
+                    <div class="w-100 mb-2">
+                        <div class="alert alert-warning d-flex align-items-start gap-2 mb-0" role="alert">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 mt-1" viewBox="0 0 16 16">
+                                <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+                            </svg>
+                            <div>
+                                <strong>Dados demográficos pendentes!</strong><br>
+                                {{ session('erro_demograficos') }}
+                            </div>
+                        </div>
+                    </div>
+                @endif
+
                 {{-- Ação Principal (Sempre visível para o usuário final) --}}
                 @auth
                     <form action="{{ route('atividades.presenca.checkin', $atividade) }}" method="POST" class="d-inline">

--- a/resources/views/curadoria_demograficos/index.blade.php
+++ b/resources/views/curadoria_demograficos/index.blade.php
@@ -1,0 +1,109 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-md-12">
+            <div class="card ev-card">
+                <div class="card-header bg-engaja text-white">
+                    <h5 class="mb-0 fw-bold">Curadoria de Dados Demográficos</h5>
+                </div>
+                <div class="card-body">
+                    @if (session('success'))
+                        <div class="alert alert-success">
+                            {{ session('success') }}
+                        </div>
+                    @endif
+                    @if (session('error'))
+                        <div class="alert alert-danger">
+                            {{ session('error') }}
+                        </div>
+                    @endif
+
+                    <p class="mb-4">
+                        Abaixo estão os dados demográficos preenchidos durante a confirmação de presença via QR Code. 
+                        Revise e vincule os dados ao cadastro do usuário.
+                    </p>
+
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Usuário (E-mail / CPF)</th>
+                                    <th>Gênero</th>
+                                    <th>Raça / Cor</th>
+                                    <th>Comunidade Tradicional</th>
+                                    <th>Faixa Etária</th>
+                                    <th>PcD</th>
+                                    <th>Orientação Sexual</th>
+                                    <th>Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse ($curadorias as $curadoria)
+                                    <tr>
+                                        <td>
+                                            <strong>{{ $curadoria->user->name ?? 'N/A' }}</strong><br>
+                                            <small class="text-muted">{{ $curadoria->user->email ?? '' }}</small>
+                                            @if($curadoria->user && $curadoria->user->demograficosCompletos())
+                                                <br><span class="badge bg-warning text-dark mt-1" title="Este usuário já possui os dados demográficos completamente preenchidos no sistema. Vincular irá sobrescrever."> Dados já completos</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            {{ $curadoria->identidade_genero }}
+                                            @if($curadoria->identidade_genero === 'Outro' && $curadoria->identidade_genero_outro)
+                                                <br><small class="text-muted">({{ $curadoria->identidade_genero_outro }})</small>
+                                            @endif
+                                        </td>
+                                        <td>{{ $curadoria->raca_cor }}</td>
+                                        <td>
+                                            {{ $curadoria->comunidade_tradicional }}
+                                            @if($curadoria->comunidade_tradicional === 'Outro' && $curadoria->comunidade_tradicional_outro)
+                                                <br><small class="text-muted">({{ $curadoria->comunidade_tradicional_outro }})</small>
+                                            @endif
+                                        </td>
+                                        <td>{{ $curadoria->faixa_etaria }}</td>
+                                        <td>{{ $curadoria->pcd }}</td>
+                                        <td>
+                                            {{ $curadoria->orientacao_sexual }}
+                                            @if($curadoria->orientacao_sexual === 'Outra' && $curadoria->orientacao_sexual_outra)
+                                                <br><small class="text-muted">({{ $curadoria->orientacao_sexual_outra }})</small>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <div class="d-flex gap-2">
+                                                <form action="{{ route('curadoria.vincular', $curadoria->id) }}" method="POST">
+                                                    @csrf
+                                                    <button type="submit" class="btn btn-sm btn-engaja" title="Vincular dados ao usuário" onclick="return confirm('Deseja realmente vincular esses dados ao usuário?')">
+                                                        Vincular
+                                                    </button>
+                                                </form>
+
+                                                <form action="{{ route('curadoria.destroy', $curadoria->id) }}" method="POST">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger" title="Excluir este registro" onclick="return confirm('Deseja realmente excluir este registro?')">
+                                                        Excluir
+                                                    </button>
+                                                </form>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="8" class="text-center text-muted py-4">Nenhum dado pendente para curadoria.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                    
+                    <div class="mt-3">
+                        {{ $curadorias->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/partials/admin-sidebar.blade.php
+++ b/resources/views/layouts/partials/admin-sidebar.blade.php
@@ -187,6 +187,9 @@
                 <a class="admin-nav-link {{ request()->routeIs('usuarios.sem-vinculo.*') ? 'active' : '' }}" href="{{ route('usuarios.sem-vinculo.index') }}">
                   Usuários sem vínculo
                 </a>
+                <a class="admin-nav-link {{ request()->routeIs('curadoria.index') ? 'active' : '' }}" href="{{ route('curadoria.index') }}">
+                  Curadoria de Demográficos
+                </a>
               @endhasanyrole
             </div>
           </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -367,6 +367,7 @@ Route::post('/eventos/cadastro-e-inscricao/store', [EventoController::class, 'st
 
 Route::get('/presenca/{atividade}/confirmar', [PresencaController::class, 'confirmarPresenca'])->name('presenca.confirmar');
 Route::post('/presenca/{atividade}/confirmar', [PresencaController::class, 'store'])->name('presenca.store');
+Route::post('/presenca/{atividade}/demograficos', [PresencaController::class, 'salvarDemograficosEConfirmar'])->name('presenca.demograficos');
 
 Route::middleware(['auth'])->group(function () {
     Route::get('/meus-certificados', [ProfileController::class, 'certificados'])->name('profile.certificados');
@@ -392,6 +393,10 @@ Route::middleware(['auth', 'role:administrador|gerente'])->group(function () {
     Route::put('/certificados/{certificado}', [CertificadoController::class, 'update'])
         ->whereNumber('certificado')
         ->name('certificados.update');
+
+    Route::get('/curadoria-demograficos', [\App\Http\Controllers\CuradoriaDemograficoController::class, 'index'])->name('curadoria.index');
+    Route::post('/curadoria-demograficos/{curadoria}/vincular', [\App\Http\Controllers\CuradoriaDemograficoController::class, 'vincular'])->name('curadoria.vincular');
+    Route::delete('/curadoria-demograficos/{curadoria}', [\App\Http\Controllers\CuradoriaDemograficoController::class, 'destroy'])->name('curadoria.destroy');
 });
 
 Route::get('/formulario-avaliacao/{avaliacao}', [AvaliacaoController::class, 'formularioAvaliacao'])->name('avaliacao.formulario');

--- a/tests/Feature/PresencaFluxoQrCodeTest.php
+++ b/tests/Feature/PresencaFluxoQrCodeTest.php
@@ -1,0 +1,429 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Atividade;
+use App\Models\Eixo;
+use App\Models\Evento;
+use App\Models\Participante;
+use App\Models\Presenca;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Testa o fluxo completo de confirmação de presença via QR Code / link público.
+ *
+ * Rota: GET  /presenca/{atividade}/confirmar           → exibe o formulário
+ *       POST /presenca/{atividade}/confirmar           → processa a confirmação / abre modal para dados incompletos
+ *       POST /presenca/{atividade}/demograficos        → salva dados demográficos e confirma presença
+ *
+ * Qualquer pessoa (mesmo deslogada via QR code) pode preencher os dados demográficos
+ * pendentes do participante e confirmar a presença em um único fluxo.
+ */
+class PresencaFluxoQrCodeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /** Cria um usuário com todos os campos demográficos obrigatórios preenchidos. */
+    private function criarUsuarioComDemograficos(array $extra = []): User
+    {
+        return User::factory()->create(array_merge([
+            'identidade_genero'      => 'Homem Cisgênero',
+            'raca_cor'               => 'Parda',
+            'comunidade_tradicional' => 'Não',
+            'faixa_etaria'           => 'Adulto (18 a 59 anos)',
+            'pcd'                    => 'Não',
+            'orientacao_sexual'      => 'Heterossexual',
+        ], $extra));
+    }
+
+    /** Cria um usuário SEM dados demográficos. */
+    private function criarUsuarioSemDemograficos(array $extra = []): User
+    {
+        return User::factory()->create($extra);
+    }
+
+    /** Cria uma Atividade com presença aberta. */
+    private function criarAtividadeAtiva(): Atividade
+    {
+        $eixo   = Eixo::create(['nome' => 'Eixo Teste']);
+        $evento = Evento::factory()->create(['eixo_id' => $eixo->id]);
+
+        return Atividade::factory()->create([
+            'evento_id'      => $evento->id,
+            'presenca_ativa' => true,
+        ]);
+    }
+
+    /** Retorna os dados demográficos válidos para o formulário. */
+    private function dadosDemograficosValidos(): array
+    {
+        return [
+            'identidade_genero'      => 'Homem Cisgênero',
+            'raca_cor'               => 'Parda',
+            'comunidade_tradicional' => 'Não',
+            'faixa_etaria'           => 'Adulto (18 a 59 anos)',
+            'pcd'                    => 'Não',
+            'orientacao_sexual'      => 'Heterossexual',
+        ];
+    }
+
+    // =========================================================================
+    // 1. PÁGINA DO FORMULÁRIO (GET)
+    // =========================================================================
+
+    public function test_pagina_de_confirmacao_via_qr_e_acessivel_por_qualquer_pessoa(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+
+        $response = $this->get(route('presenca.confirmar', $atividade));
+
+        $response->assertOk();
+        $response->assertSee('E-mail, CPF ou telefone');
+    }
+
+    // =========================================================================
+    // 2. DETECÇÃO DE DADOS DEMOGRÁFICOS INCOMPLETOS (POST /confirmar)
+    // =========================================================================
+
+    public function test_store_redireciona_com_token_quando_usuario_sem_demograficos(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos(['email' => 'sem.dados@test.com']);
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        // Visitante deslogado buscando por e-mail
+        $response = $this
+            ->from(route('presenca.confirmar', $atividade))
+            ->post(route('presenca.store', $atividade), ['campo' => $user->email]);
+
+        // Redireciona com as flags para abrir o modal de dados demográficos
+        $response->assertRedirect(route('presenca.confirmar', $atividade));
+        $response->assertSessionHas('demograficos_pendentes', true);
+        $response->assertSessionHas('demograficos_user_token');
+        $response->assertSessionHas('demograficos_user_nome', $user->name);
+        $response->assertSessionHas('demograficos_campo_input', $user->email);
+
+        // NÃO deve criar presença ainda
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_store_redireciona_com_token_quando_encontrado_por_cpf_sem_demograficos(): void
+    {
+        $atividade    = $this->criarAtividadeAtiva();
+        $user         = $this->criarUsuarioSemDemograficos();
+        $participante = Participante::firstOrCreate(['user_id' => $user->id]);
+        $participante->update(['cpf' => '390.533.447-05']);
+
+        $response = $this
+            ->from(route('presenca.confirmar', $atividade))
+            ->post(route('presenca.store', $atividade), ['campo' => '390.533.447-05']);
+
+        $response->assertRedirect(route('presenca.confirmar', $atividade));
+        $response->assertSessionHas('demograficos_pendentes', true);
+        $response->assertSessionHas('demograficos_user_token');
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_store_redireciona_com_token_quando_encontrado_por_telefone_sem_demograficos(): void
+    {
+        $atividade    = $this->criarAtividadeAtiva();
+        $user         = $this->criarUsuarioSemDemograficos();
+        $participante = Participante::firstOrCreate(['user_id' => $user->id]);
+        $participante->update(['telefone' => '85999999999']);
+
+        $response = $this
+            ->from(route('presenca.confirmar', $atividade))
+            ->post(route('presenca.store', $atividade), ['campo' => '85999999999']);
+
+        $response->assertRedirect(route('presenca.confirmar', $atividade));
+        $response->assertSessionHas('demograficos_pendentes', true);
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_pagina_exibe_modal_e_nome_do_usuario_com_demograficos_pendentes(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+
+        $pageResponse = $this
+            ->withSession([
+                'demograficos_pendentes'    => true,
+                'demograficos_user_token'   => encrypt(999),
+                'demograficos_user_nome'    => 'João Silva',
+                'demograficos_campo_input'  => 'joao@test.com',
+            ])
+            ->get(route('presenca.confirmar', $atividade));
+
+        $pageResponse->assertOk();
+        $pageResponse->assertSee('modalDemograficos');
+        $pageResponse->assertSee('João Silva');
+        $pageResponse->assertSee('Preenchendo dados de');
+    }
+
+    // =========================================================================
+    // 3. SALVAR DEMOGRÁFICOS E CONFIRMAR PRESENÇA (POST /demograficos)
+    // =========================================================================
+
+    public function test_salvar_demograficos_e_confirmar_preenche_dados_e_cria_presenca(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos(['email' => 'preenchendo@test.com']);
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        $this->assertFalse($user->demograficosCompletos());
+
+        // Qualquer pessoa (mesmo visitante deslogado) envia os dados via formulário
+        $response = $this->post(route('presenca.demograficos', $atividade), array_merge(
+            $this->dadosDemograficosValidos(),
+            ['user_token' => encrypt($user->id)]
+        ));
+
+        // Redireciona para a página de confirmação com sucesso
+        $response->assertRedirect(route('presenca.confirmar', $atividade->id));
+        $response->assertSessionHas('success-presenca', 'Presença confirmada com sucesso!');
+        $response->assertSessionHas('usuario_nome', $user->name);
+
+        // Os dados demográficos do usuário NÃO devem ser atualizados diretamente
+        $user->refresh();
+        $this->assertFalse($user->demograficosCompletos());
+
+        // Os dados devem ter ido para a tabela de curadoria
+        $this->assertDatabaseCount('curadoria_demograficos', 1);
+        $this->assertDatabaseHas('curadoria_demograficos', [
+            'user_id'           => $user->id,
+            'identidade_genero' => 'Homem Cisgênero',
+            'raca_cor'          => 'Parda',
+            'vinculado'         => false,
+        ]);
+
+        // A presença deve ter sido criada
+        $this->assertDatabaseCount('presencas', 1);
+        $this->assertDatabaseHas('presencas', ['status' => 'presente']);
+    }
+
+    public function test_salvar_demograficos_cria_inscricao_automaticamente(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos();
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        $this->assertDatabaseCount('inscricaos', 0);
+
+        $this->post(route('presenca.demograficos', $atividade), array_merge(
+            $this->dadosDemograficosValidos(),
+            ['user_token' => encrypt($user->id)]
+        ));
+
+        $this->assertDatabaseCount('inscricaos', 1);
+        $this->assertDatabaseHas('inscricaos', [
+            'atividade_id' => $atividade->id,
+            'evento_id'    => $atividade->evento_id,
+        ]);
+    }
+
+    public function test_salvar_demograficos_gera_token_de_avaliacao(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos();
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        $response = $this->post(route('presenca.demograficos', $atividade), array_merge(
+            $this->dadosDemograficosValidos(),
+            ['user_token' => encrypt($user->id)]
+        ));
+
+        $response->assertSessionHas('avaliacao_token');
+        $response->assertSessionHas('avaliacao_disponivel', true);
+    }
+
+    public function test_salvar_demograficos_falha_com_token_invalido(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+
+        $response = $this->post(route('presenca.demograficos', $atividade), array_merge(
+            $this->dadosDemograficosValidos(),
+            ['user_token' => 'token-invalido-nao-criptografado']
+        ));
+
+        $response->assertRedirect(route('presenca.confirmar', $atividade));
+        $response->assertSessionHas('error');
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_salvar_demograficos_falha_sem_campos_obrigatorios(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos();
+
+        $response = $this
+            ->from(route('presenca.confirmar', $atividade))
+            ->post(route('presenca.demograficos', $atividade), [
+                'user_token' => encrypt($user->id),
+                // Campos obrigatórios ausentes intencionalmente
+            ]);
+
+        $response->assertSessionHasErrors([
+            'identidade_genero',
+            'raca_cor',
+            'comunidade_tradicional',
+            'faixa_etaria',
+            'pcd',
+            'orientacao_sexual',
+        ]);
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_salvar_demograficos_nao_duplica_presenca_em_segunda_chamada(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos();
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        $payload = array_merge($this->dadosDemograficosValidos(), ['user_token' => encrypt($user->id)]);
+
+        $this->post(route('presenca.demograficos', $atividade), $payload);
+        $this->assertDatabaseCount('presencas', 1);
+
+        $this->post(route('presenca.demograficos', $atividade), $payload);
+        $this->assertDatabaseCount('presencas', 1);
+    }
+
+    // =========================================================================
+    // 4. CONFIRMAÇÃO BEM-SUCEDIDA VIA BUSCA DIRETA (dados já completos)
+    // =========================================================================
+
+    public function test_confirmacao_bem_sucedida_por_email_quando_dados_completos(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioComDemograficos(['email' => 'confirmado@test.com']);
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        $response = $this->post(route('presenca.store', $atividade), ['campo' => $user->email]);
+
+        $response->assertRedirect(route('presenca.confirmar', $atividade->id));
+        $response->assertSessionHas('success-presenca', 'Presença confirmada com sucesso!');
+        $response->assertSessionHas('usuario_nome', $user->name);
+
+        $this->assertDatabaseCount('presencas', 1);
+        $this->assertDatabaseHas('presencas', ['status' => 'presente']);
+    }
+
+    public function test_confirmacao_bem_sucedida_define_avaliacao_respondida_como_false(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioComDemograficos(['email' => 'flag@test.com']);
+        Participante::firstOrCreate(['user_id' => $user->id]);
+
+        $this->post(route('presenca.store', $atividade), ['campo' => $user->email]);
+
+        $presenca = Presenca::first();
+        $this->assertNotNull($presenca);
+        $this->assertFalse((bool) $presenca->avaliacao_respondida);
+    }
+
+    // =========================================================================
+    // 5. USUÁRIO / PARTICIPANTE NÃO ENCONTRADO
+    // =========================================================================
+
+    public function test_confirmacao_falha_quando_campo_nao_corresponde_a_nenhum_registro(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+
+        $response = $this
+            ->from(route('presenca.confirmar', $atividade))
+            ->post(route('presenca.store', $atividade), ['campo' => 'naoexiste@nenhum.com']);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $response->assertSessionHas('show_register_button', true);
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_campo_obrigatorio_e_validado_no_post(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+
+        $response = $this
+            ->from(route('presenca.confirmar', $atividade))
+            ->post(route('presenca.store', $atividade), ['campo' => '']);
+
+        $response->assertSessionHasErrors('campo');
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    // =========================================================================
+    // 6. CHECKIN AUTENTICADO (/atividades/{id}/presenca/checkin)
+    // =========================================================================
+
+    public function test_checkin_autenticado_e_bloqueado_sem_dados_demograficos(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioSemDemograficos();
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('atividades.show', $atividade))
+            ->post(route('atividades.presenca.checkin', $atividade));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('erro_demograficos');
+        $this->assertDatabaseCount('presencas', 0);
+    }
+
+    public function test_checkin_autenticado_bem_sucedido_cria_presenca(): void
+    {
+        $atividade = $this->criarAtividadeAtiva();
+        $user      = $this->criarUsuarioComDemograficos();
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('atividades.show', $atividade))
+            ->post(route('atividades.presenca.checkin', $atividade));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success', 'Presença confirmada com sucesso!');
+        $this->assertDatabaseCount('presencas', 1);
+        $this->assertDatabaseHas('presencas', ['status' => 'presente']);
+    }
+
+    // =========================================================================
+    // 7. MÉTODO demograficosCompletos() NO MODEL User
+    // =========================================================================
+
+    public function test_metodo_demograficos_completos_retorna_true_quando_todos_campos_preenchidos(): void
+    {
+        $user = $this->criarUsuarioComDemograficos();
+        $this->assertTrue($user->demograficosCompletos());
+    }
+
+    public function test_metodo_demograficos_completos_retorna_false_quando_algum_campo_falta(): void
+    {
+        $camposObrigatorios = [
+            'identidade_genero', 'raca_cor', 'comunidade_tradicional',
+            'faixa_etaria', 'pcd', 'orientacao_sexual',
+        ];
+
+        foreach ($camposObrigatorios as $campo) {
+            $dados = [
+                'identidade_genero'      => 'Homem Cisgênero',
+                'raca_cor'               => 'Parda',
+                'comunidade_tradicional' => 'Não',
+                'faixa_etaria'           => 'Adulto (18 a 59 anos)',
+                'pcd'                    => 'Não',
+                'orientacao_sexual'      => 'Heterossexual',
+            ];
+            $dados[$campo] = null;
+
+            $user = User::factory()->create($dados);
+            $this->assertFalse(
+                $user->demograficosCompletos(),
+                "Esperado false quando o campo '{$campo}' está nulo."
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Adicionada nova funcionalidade para curadoria de dados demográficos, permitindo que administradores e gerentes vinculem dados a usuários.
- Criada a tabela 'curadoria_demograficos' para armazenar dados demográficos pendentes.
- Implementados métodos no CuradoriaDemograficoController para listar, vincular e excluir registros de curadoria.
- Atualizada a rota para incluir endpoints para curadoria de demográficos.
- Adicionada lógica para exibir alertas de dados demográficos pendentes na página de atividades.
- Criados testes para validar o fluxo de confirmação de presença via QR Code, incluindo a manipulação de dados demográficos.