### PR TITLE
feat(cartas): reorganiza layout e estilo do módulo de cartas

### DIFF
--- a/resources/views/cartas/cartas/show.blade.php
+++ b/resources/views/cartas/cartas/show.blade.php
@@ -61,7 +61,7 @@
                             $statusClass = match (true) {
                                 str_starts_with($statusLabel, 'Respondida') || $statusLabel === 'Recebida' => 'cpe-pill--green',
                                 $statusLabel === 'Em preparação' => 'cpe-pill--yellow',
-                                $statusLabel === 'Ajuste solicitado' => 'cpe-pill--purple',
+                                $statusLabel === 'Ajuste solicitado' => 'cpe-pill--red',
                                 default => 'cpe-pill--blue',
                             };
 
@@ -123,9 +123,58 @@
                     @php($destinatarioPanelNome = $mensagem->destinatarioUsuario?->nome ?? $mensagem->destinatarioParticipante?->nome ?? 'Destinatário')
                     <div class="cpe-letter-stage">
                         <div class="cpe-letter-header">
-                            <span class="cpe-letter-header__party">De: {{ $remetentePanelNome }}<br>Para: {{ $destinatarioPanelNome }}</span>
-                            <span class="cpe-letter-header__date">{{ optional($mensagem->enviada_em ?? $mensagem->created_at)->format('d/m/Y') }}</span>
+                            <span class="cpe-letter-header__party">
+                                De: {{ $remetentePanelNome }}<br>Para: {{ $destinatarioPanelNome }}
+                                <span class="cpe-letter-header__date">{{ optional($mensagem->enviada_em ?? $mensagem->created_at)->format('d/m/Y') }}</span>
+                            </span>
+
+                            @if(! ($gestor && $mensagem->status === 'aguardando_verificacao'))
+                                <div class="cpe-letter-actions">
+                                    @if($mensagem->anexo_original_path || $mensagem->arquivo_final_path)
+                                        <button type="button" class="cpe-button cpe-button--ghost" data-print-src="{{ route('cartas.mensagens.preview', $mensagem) }}">Imprimir</button>
+                                    @else
+                                        <button type="button" class="cpe-button cpe-button--ghost">Imprimir</button>
+                                    @endif
+
+                                    @if($loop->last)
+                                        @if($gestor)
+                                            @if($carta->podeEducandoEnviar())
+                                                <button type="button" class="cpe-button" data-modal-open="addCartaModal">Adicionar carta</button>
+                                            @endif
+                                        @else
+                                            @if($carta->podeVoluntarioEnviar())
+                                                <button type="button" class="cpe-button" data-modal-open="respondCartaModal">Responder {{ $remetentePrimeiroNome }}</button>
+                                            @endif
+                                        @endif
+                                    @endif
+                                </div>
+                            @endif
                         </div>
+
+                        @if($gestor && $mensagem->status === 'aguardando_verificacao')
+                            <div class="cpe-verification-box">
+                                <form method="POST" class="cpe-adjustment-form">
+                                    @csrf
+                                    <textarea name="parecer_verificacao" class="cpe-textarea" placeholder="Informe o ajuste solicitado ao voluntário, caso seja necessário."></textarea>
+                                    <div class="cpe-letter-actions">
+                                        <button type="button" class="cpe-button cpe-button--ghost" data-aside-close>Fechar</button>
+                                        <button type="submit" formaction="{{ route('cartas.mensagens.adjustment', $mensagem) }}" class="cpe-button cpe-button--ghost">Solicitar ajuste</button>
+                                        <button type="submit" formaction="{{ route('cartas.mensagens.approve', $mensagem) }}" class="cpe-button">Aprovar resposta</button>
+                                    </div>
+                                </form>
+                            </div>
+                        @elseif($mensagem->status === 'ajuste_solicitado')
+                            <div class="cpe-verification-note">
+                                <strong>Ajuste solicitado:</strong>
+                                <span>{{ $mensagem->parecer_verificacao ?: 'Revise sua resposta e envie novamente para verificação.' }}</span>
+
+                                @if(! $gestor && $mensagem->isEditavelPor(Auth::user()))
+                                    <button type="button" class="cpe-button" data-aside-open="aside-adjustMensagem-{{ $mensagem->id }}">
+                                        Realizar ajuste
+                                    </button>
+                                @endif
+                            </div>
+                        @endif
 
                         @if($mensagem->anexo_original_path || $mensagem->arquivo_final_path)
                             @if(str_starts_with((string) $mensagemMime, 'image/'))
@@ -143,53 +192,6 @@
                             <div class="cpe-letter-preview cpe-aside-preview">{{ $mensagem->texto ?? 'Carta sem visualização disponível.' }}</div>
                         @endif
                     </div>
-
-                    @if(! ($gestor && $mensagem->status === 'aguardando_verificacao'))
-                        <div class="cpe-modal-actions">
-                            @if($mensagem->anexo_original_path || $mensagem->arquivo_final_path)
-                                <button type="button" class="cpe-button cpe-button--ghost" data-print-src="{{ route('cartas.mensagens.preview', $mensagem) }}">Imprimir</button>
-                            @else
-                                <button type="button" class="cpe-button cpe-button--ghost">Imprimir</button>
-                            @endif
-
-                            @if($loop->last)
-                                @if($gestor)
-                                    @if($carta->podeEducandoEnviar())
-                                        <button type="button" class="cpe-button" data-modal-open="addCartaModal">Adicionar carta</button>
-                                    @endif
-                                @else
-                                    @if($carta->podeVoluntarioEnviar())
-                                        <button type="button" class="cpe-button" data-modal-open="respondCartaModal">Responder {{ $remetentePrimeiroNome }}</button>
-                                    @endif
-                                @endif
-                            @endif
-                        </div>
-                    @endif
-
-                    @if($gestor && $mensagem->status === 'aguardando_verificacao')
-                        <div class="cpe-verification-box">
-                            <form method="POST" class="cpe-adjustment-form">
-                                @csrf
-                                <textarea name="parecer_verificacao" class="cpe-textarea" placeholder="Informe o ajuste solicitado ao voluntário, caso seja necessário."></textarea>
-                                <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px;">
-                                    <button type="button" class="cpe-button cpe-button--ghost" data-aside-close>Fechar</button>
-                                    <button type="submit" formaction="{{ route('cartas.mensagens.adjustment', $mensagem) }}" class="cpe-button cpe-button--ghost">Solicitar ajuste</button>
-                                    <button type="submit" formaction="{{ route('cartas.mensagens.approve', $mensagem) }}" class="cpe-button">Aprovar resposta</button>
-                                </div>
-                            </form>
-                        </div>
-                    @elseif($mensagem->status === 'ajuste_solicitado')
-                        <div class="cpe-verification-note">
-                            <strong>Ajuste solicitado:</strong>
-                            <span>{{ $mensagem->parecer_verificacao ?: 'Revise sua resposta e envie novamente para verificação.' }}</span>
-
-                            @if(! $gestor && $mensagem->isEditavelPor(Auth::user()))
-                                <button type="button" class="cpe-button" data-aside-open="aside-adjustMensagem-{{ $mensagem->id }}">
-                                    Realizar ajuste
-                                </button>
-                            @endif
-                        </div>
-                    @endif
                 </div>
             @endforeach
 
@@ -355,6 +357,7 @@
 
         .cpe-conversation > .cpe-logo-top {
             width: 100%;
+            margin-bottom: 24px;
         }
 
         /* Nesta tela o titulo compete com a lista de mensagens na barra lateral estreita */
@@ -447,10 +450,14 @@
             align-self: center;
         }
 
-        /* Visualizador da carta: centralizado na tela inteira */
+        /* Visualizador da carta: centralizado na tela inteira.
+           A margem direita espelha a largura da barra lateral, entao o eixo
+           central do painel coincide com o centro da viewport, e nao com o
+           centro do espaco que sobra ao lado da lista de mensagens. */
         .cpe-conversation__aside {
             flex: 1;
             min-width: 0;
+            margin-right: var(--cpe-sidebar-w);
             background: transparent;
             min-height: calc(100vh - 130px);
             border-left: 0;
@@ -501,6 +508,50 @@
             font-size: 14px;
         }
 
+        /* Acoes logo abaixo do "De:/Para:", com botoes compactos alinhados a direita */
+        .cpe-letter-actions {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+
+        /* Informacoes e botoes formam uma linha unica, com as bases alinhadas */
+        .cpe-letter-header .cpe-letter-actions {
+            flex: none;
+            align-self: flex-end;
+        }
+
+        /* Respiro entre o parecer e os botoes de decisao do gestor */
+        .cpe-adjustment-form .cpe-letter-actions {
+            margin-top: 6px;
+        }
+
+        .cpe-letter-stage .cpe-letter-actions .cpe-button {
+            width: auto;
+            min-width: 0;
+            height: 34px;
+            padding: 0 14px;
+            font-size: 13px;
+            font-weight: 700;
+        }
+
+        .cpe-letter-stage > .cpe-verification-box,
+        .cpe-letter-stage > .cpe-verification-note {
+            border-top: 0;
+            margin: -12px 0 0;
+            padding-top: 0;
+        }
+
+        .cpe-letter-stage > .cpe-verification-note .cpe-button {
+            justify-self: end;
+            width: auto;
+            height: 34px;
+            padding: 0 14px;
+            font-size: 13px;
+        }
+
         .cpe-letter-stage {
             display: flex;
             flex-direction: column;
@@ -509,18 +560,23 @@
 
         .cpe-letter-header {
             display: flex;
+            flex-wrap: wrap;
             justify-content: space-between;
-            align-items: flex-end;
-            gap: 24px;
+            align-items: center;
+            gap: 16px 24px;
             color: #008bbc;
             font-weight: 500;
             font-size: 19px;
             line-height: 1.2;
         }
 
+        .cpe-letter-header__party {
+            min-width: 0;
+        }
+
         .cpe-letter-header__date {
-            flex: none;
-            text-align: right;
+            display: block;
+            margin-top: 4px;
         }
 
         .cpe-conversation .cpe-letter-preview--media {
@@ -703,6 +759,7 @@
             .cpe-conversation__aside {
                 width: 100%;
                 min-height: 0;
+                margin-right: 0;
             }
         }
 

--- a/resources/views/cartas/gestor/_table.blade.php
+++ b/resources/views/cartas/gestor/_table.blade.php
@@ -20,7 +20,7 @@
                         $ultimoStatus = $carta->ultimaMensagem?->status ?? $carta->status;
                         $statusClass = match (true) {
                             $carta->status === 'respondida' => 'cpe-pill--green',
-                            $carta->status === 'aguardando_ajuste' || $ultimoStatus === 'ajuste_solicitado' => 'cpe-pill--purple',
+                            $carta->status === 'aguardando_ajuste' || $ultimoStatus === 'ajuste_solicitado' => 'cpe-pill--red',
                             str_contains($ultimoStatus, 'verificacao') => 'cpe-pill--yellow',
                             default => 'cpe-pill--blue',
                         };

--- a/resources/views/cartas/gestor/index.blade.php
+++ b/resources/views/cartas/gestor/index.blade.php
@@ -154,12 +154,12 @@
     <style>
         .cpe-manager {
             display: grid;
-            grid-template-columns: minmax(420px, 1fr) minmax(520px, 1fr);
+            grid-template-columns: minmax(320px, 26%) minmax(0, 1fr);
         }
 
         .cpe-manager__left {
             min-height: 100%;
-            padding: 0 72px;
+            padding: 0 36px;
             display: flex;
             flex-direction: column;
             border-right: 1px solid #dfd7d2;

--- a/resources/views/cartas/shared/_styles.blade.php
+++ b/resources/views/cartas/shared/_styles.blade.php
@@ -418,6 +418,11 @@
         background: rgba(150, 2, 199, 0.12);
     }
 
+    .cpe-pill--red {
+        color: #b42318;
+        background: rgba(180, 35, 24, 0.12);
+    }
+
     .cpe-pill--priority {
         color: #9a3412;
         background: #ffedd5;


### PR DESCRIPTION
- Muda cor do status "ajuste solicitado" de roxo para vermelho (pill--red)
- Aumenta área da tabela do dashboard (26% esquerda / 74% direita)
- Reduz padding lateral da coluna esquerda (72px → 36px)
- Move botões de ação para logo abaixo do cabeçalho "De: / Para:"
- Alinha informações e botões como uma linha única (bases niveladas)
- Centraliza visualização da carta na tela inteira (não apenas no espaço restante)
- Adiciona espaço entre logo e conteúdo (margin-bottom 24px)
- Torna botões de ação mais compactos (altura 34px, font 13px)

Espira de 6px entre campo de parecer e botões de decisão do gestor. Testes: 70 passaram, 1 falha pré-existente no CartaDownloadBatchTest.